### PR TITLE
Port custom heaps support

### DIFF
--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
@@ -229,7 +229,7 @@ namespace TerraFX.Interop
         [return: NativeTypeName("HRESULT")]
         public int CreatePool([NativeTypeName("const POOL_DESC*")] D3D12MA_POOL_DESC* pPoolDesc, D3D12MA_Pool** ppPool)
         {
-            if ((pPoolDesc == null) || (ppPool == null) || !IsHeapTypeValid(pPoolDesc->HeapType) || ((pPoolDesc->MaxBlockCount > 0) && (pPoolDesc->MaxBlockCount < pPoolDesc->MinBlockCount)))
+            if ((pPoolDesc == null) || (ppPool == null) || ((pPoolDesc->MaxBlockCount > 0) && (pPoolDesc->MaxBlockCount < pPoolDesc->MinBlockCount)))
             {
                 D3D12MA_ASSERT(false); // "Invalid arguments passed to Allocator::CreatePool."
                 return E_INVALIDARG;
@@ -250,7 +250,7 @@ namespace TerraFX.Interop
 
             if (SUCCEEDED(hr))
             {
-                m_Pimpl->RegisterPool(*ppPool, pPoolDesc->HeapType);
+                m_Pimpl->RegisterPool(*ppPool, pPoolDesc->HeapProperties.Type);
             }
             else
             {

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_POOL_DESC.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_POOL_DESC.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Advanced Micro Devices, Inc. All rights reserved. Licensed under the MIT License (MIT).
 
 using static TerraFX.Interop.Windows;
-using static TerraFX.Interop.D3D12_HEAP_TYPE;
 using static TerraFX.Interop.D3D12_HEAP_FLAGS;
 
 namespace TerraFX.Interop
@@ -13,10 +12,10 @@ namespace TerraFX.Interop
     public struct D3D12MA_POOL_DESC
     {
         /// <summary>
-        /// The type of memory heap where allocations of this pool should be placed.
-        /// <para>It must be one of: <see cref="D3D12_HEAP_TYPE_DEFAULT"/>, <see cref="D3D12_HEAP_TYPE_UPLOAD"/>, <see cref="D3D12_HEAP_TYPE_READBACK"/>.</para>
+        /// The parameters of memory heap where allocations of this pool should be placed.
+        /// <para>In the simplest case, just fill it with zeros and set <see cref="D3D12_HEAP_PROPERTIES.Type"/> to one of: <see cref="D3D12_HEAP_TYPE.D3D12_HEAP_TYPE_DEFAULT"/>, <see cref="D3D12_HEAP_TYPE.D3D12_HEAP_TYPE_UPLOAD"/>, <see cref="D3D12_HEAP_TYPE.D3D12_HEAP_TYPE_READBACK"/>. Additional parameters can be used e.g.to utilize UMA.</para>
         /// </summary>
-        public D3D12_HEAP_TYPE HeapType;
+        public D3D12_HEAP_PROPERTIES HeapProperties;
 
         /// <summary>
         /// Heap flags to be used when allocating heaps of this pool.

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
@@ -94,7 +94,7 @@ namespace TerraFX.Interop
 
         void IDisposable.Dispose()
         {
-            m_Pimpl->GetAllocator()->UnregisterPool(ref this, m_Pimpl->GetDesc()->HeapType);
+            m_Pimpl->GetAllocator()->UnregisterPool(ref this, m_Pimpl->GetDesc()->HeapProperties.Type);
             D3D12MA_DELETE(m_Pimpl->GetAllocator()->GetAllocs(), m_Pimpl);
         }
     }

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Stats.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Stats.cs
@@ -17,7 +17,7 @@ namespace TerraFX.Interop
         /// <summary>Total statistics from all heap types.</summary>
         public D3D12MA_StatInfo Total;
 
-        /// <summary>One StatInfo for each type of heap located at the following indices: 0 - DEFAULT, 1 - UPLOAD, 2 - READBACK.</summary>
+        /// <summary>One StatInfo for each type of heap located at the following indices: 0 - DEFAULT, 1 - UPLOAD, 2 - READBACK, 3 - CUSTOM.</summary>
         [NativeTypeName("StatInfo HeapType[HEAP_TYPE_COUNT]")]
         public __Stats_e__FixedBuffer HeapType;
 
@@ -27,6 +27,7 @@ namespace TerraFX.Interop
             public D3D12MA_StatInfo e0;
             public D3D12MA_StatInfo e1;
             public D3D12MA_StatInfo e2;
+            public D3D12MA_StatInfo e3;
 
             public ref D3D12MA_StatInfo this[int index]
             {

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MemAlloc.cs
@@ -12,7 +12,7 @@ namespace TerraFX.Interop
 
         /// <summary>Number of D3D12 memory heap types supported.</summary>
         [NativeTypeName("UINT")]
-        public const uint D3D12MA_HEAP_TYPE_COUNT = 3;
+        public const uint D3D12MA_HEAP_TYPE_COUNT = 4;
 
         /// <summary>
         /// Creates new main <see cref="D3D12MA_Allocator"/> object and returns it through <paramref name="ppAllocator"/>.

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_AllocatorPimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_AllocatorPimpl.cs
@@ -294,6 +294,10 @@ namespace TerraFX.Interop
                 *ppvResource = null;
             }
 
+            if (pAllocDesc->CustomPool == null && !IsHeapTypeStandard(pAllocDesc->HeapType))
+            {
+                return E_INVALIDARG;
+            }
             D3D12MA_ALLOCATION_DESC finalAllocDesc = *pAllocDesc;
 
             D3D12_RESOURCE_DESC finalResourceDesc = *pResourceDesc;
@@ -468,6 +472,11 @@ namespace TerraFX.Interop
                 return E_NOINTERFACE;
             }
 
+            if (pAllocDesc->CustomPool == null && !IsHeapTypeStandard(pAllocDesc->HeapType))
+            {
+                return E_INVALIDARG;
+            }
+
             D3D12MA_ALLOCATION_DESC finalAllocDesc = *pAllocDesc;
 
             D3D12_RESOURCE_DESC1 finalResourceDesc = *pResourceDesc;
@@ -606,6 +615,10 @@ namespace TerraFX.Interop
             }
             else
             {
+                if (!IsHeapTypeStandard(pAllocDesc->HeapType))
+                {
+                    return E_INVALIDARG;
+                }
                 D3D12MA_ALLOCATION_DESC finalAllocDesc = *pAllocDesc;
 
                 uint defaultPoolIndex = CalcDefaultPoolIndex(pAllocDesc);
@@ -676,6 +689,10 @@ namespace TerraFX.Interop
                 return E_INVALIDARG;
             }
 
+            if (!IsHeapTypeStandard(pAllocDesc->HeapType))
+            {
+                return E_INVALIDARG;
+            }
             return AllocateHeap1(pAllocDesc, pAllocInfo, pProtectedSession, ppAllocation);
         }
 
@@ -716,7 +733,7 @@ namespace TerraFX.Interop
         [return: NativeTypeName("HRESULT")]
         public int SetDefaultHeapMinBytes(D3D12_HEAP_TYPE heapType, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong minBytes)
         {
-            if (heapType != D3D12_HEAP_TYPE_DEFAULT && heapType != D3D12_HEAP_TYPE_UPLOAD && heapType != D3D12_HEAP_TYPE_READBACK)
+            if (!IsHeapTypeStandard(heapType))
             {
                 D3D12MA_ASSERT(false); // "Allocator::SetDefaultHeapMinBytes: Invalid heapType passed."
                 return E_INVALIDARG;
@@ -875,7 +892,7 @@ namespace TerraFX.Interop
 
             if (SupportsResourceHeapTier2())
             {
-                for (nuint heapTypeIndex = 0; heapTypeIndex < D3D12MA_DEFAULT_POOL_HEAP_TYPE_COUNT; ++heapTypeIndex)
+                for (nuint heapTypeIndex = 0; heapTypeIndex < D3D12MA_STANDARD_HEAP_TYPE_COUNT; ++heapTypeIndex)
                 {
                     D3D12MA_BlockVector* pBlockVector = m_BlockVectors[(int)heapTypeIndex];
                     D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && (pBlockVector != null));
@@ -884,7 +901,7 @@ namespace TerraFX.Interop
             }
             else
             {
-                for (nuint heapTypeIndex = 0; heapTypeIndex < D3D12MA_DEFAULT_POOL_HEAP_TYPE_COUNT; ++heapTypeIndex)
+                for (nuint heapTypeIndex = 0; heapTypeIndex < D3D12MA_STANDARD_HEAP_TYPE_COUNT; ++heapTypeIndex)
                 {
                     for (nuint heapSubType = 0; heapSubType < 3; ++heapSubType)
                     {
@@ -960,6 +977,7 @@ namespace TerraFX.Interop
                 outCpuBudget->BlockBytes = Volatile.Read(ref m_Budget.m_BlockBytes[1]) + Volatile.Read(ref m_Budget.m_BlockBytes[2]);
                 outCpuBudget->AllocationBytes = Volatile.Read(ref m_Budget.m_AllocationBytes[1]) + Volatile.Read(ref m_Budget.m_AllocationBytes[2]);
             }
+            // TODO: What to do with CUSTOM?
 
             if (D3D12MA_DXGI_1_4 != 0)
             {
@@ -1091,7 +1109,7 @@ namespace TerraFX.Interop
 
                     if (SupportsResourceHeapTier2())
                     {
-                        for (nuint heapType = 0; heapType < D3D12MA_DEFAULT_POOL_HEAP_TYPE_COUNT; ++heapType)
+                        for (nuint heapType = 0; heapType < D3D12MA_STANDARD_HEAP_TYPE_COUNT; ++heapType)
                         {
                             json.WriteString(HeapTypeNames[heapType]);
                             json.BeginObject();
@@ -1107,7 +1125,7 @@ namespace TerraFX.Interop
                     }
                     else
                     {
-                        for (nuint heapType = 0; heapType < D3D12MA_DEFAULT_POOL_HEAP_TYPE_COUNT; ++heapType)
+                        for (nuint heapType = 0; heapType < D3D12MA_STANDARD_HEAP_TYPE_COUNT; ++heapType)
                         {
                             for (nuint heapSubType = 0; heapSubType < 3; ++heapSubType)
                             {

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_BlockVector.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_BlockVector.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using static TerraFX.Interop.Windows;
 using static TerraFX.Interop.D3D12MemAlloc;
 using static TerraFX.Interop.D3D12MA_ALLOCATION_FLAGS;
+using static TerraFX.Interop.D3D12_HEAP_TYPE;
 
 namespace TerraFX.Interop
 {
@@ -19,7 +20,7 @@ namespace TerraFX.Interop
     {
         private D3D12MA_AllocatorPimpl* m_hAllocator;
 
-        private D3D12_HEAP_TYPE m_HeapType;
+        private D3D12_HEAP_PROPERTIES m_HeapProps;
 
         private D3D12_HEAP_FLAGS m_HeapFlags;
 
@@ -50,10 +51,10 @@ namespace TerraFX.Interop
         [NativeTypeName("UINT")]
         private uint m_NextBlockId;
 
-        internal static void _ctor(ref D3D12MA_BlockVector pThis, D3D12MA_AllocatorPimpl* hAllocator, D3D12_HEAP_TYPE heapType, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong preferredBlockSize, [NativeTypeName("size_t")] nuint minBlockCount, [NativeTypeName("size_t")] nuint maxBlockCount, bool explicitBlockSize)
+        internal static void _ctor(ref D3D12MA_BlockVector pThis, D3D12MA_AllocatorPimpl* hAllocator, [NativeTypeName("const D3D12_HEAP_PROPERTIES&")] D3D12_HEAP_PROPERTIES* heapProps, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong preferredBlockSize, [NativeTypeName("size_t")] nuint minBlockCount, [NativeTypeName("size_t")] nuint maxBlockCount, bool explicitBlockSize)
         {
             pThis.m_hAllocator = hAllocator;
-            pThis.m_HeapType = heapType;
+            pThis.m_HeapProps = *heapProps;
             pThis.m_HeapFlags = heapFlags;
             pThis.m_PreferredBlockSize = preferredBlockSize;
             pThis.m_MinBlockCount = minBlockCount;
@@ -93,8 +94,8 @@ namespace TerraFX.Interop
             return S_OK;
         }
 
-        [return: NativeTypeName("UINT")]
-        public readonly uint GetHeapType() => (uint)m_HeapType;
+        [return: NativeTypeName("const D3D12_HEAP_PROPERTIES&")]
+        public readonly D3D12_HEAP_PROPERTIES* GetHeapProperties() => (D3D12_HEAP_PROPERTIES*)Unsafe.AsPointer(ref Unsafe.AsRef(in m_HeapProps));
 
         [return: NativeTypeName("UINT64")]
         public readonly ulong GetPreferredBlockSize() => m_PreferredBlockSize;
@@ -143,9 +144,10 @@ namespace TerraFX.Interop
             D3D12MA_NormalBlock* pBlockToDelete = null;
 
             bool budgetExceeded = false;
+            if (m_HeapProps.Type != D3D12_HEAP_TYPE_CUSTOM)
             {
                 D3D12MA_Budget budget = default;
-                m_hAllocator->GetBudgetForHeapType(&budget, m_HeapType);
+                m_hAllocator->GetBudgetForHeapType(&budget, m_HeapProps.Type);
                 budgetExceeded = budget.UsageBytes >= budget.BudgetBytes;
             }
 
@@ -404,7 +406,7 @@ namespace TerraFX.Interop
 
         public void AddStats([NativeTypeName("Stats&")] D3D12MA_Stats* outStats)
         {
-            uint heapTypeIndex = HeapTypeToIndex(m_HeapType);
+            uint heapTypeIndex = HeapTypeToIndex(m_HeapProps.Type);
             ref D3D12MA_StatInfo pStatInfo = ref outStats->HeapType[(int)heapTypeIndex];
 
             using var @lock = new D3D12MA_MutexLockRead(ref m_Mutex, m_hAllocator->UseMutex());
@@ -516,10 +518,11 @@ namespace TerraFX.Interop
                 return E_OUTOFMEMORY;
             }
 
-            ulong freeMemory;
+            ulong freeMemory = UINT64_MAX;
+            if (m_HeapProps.Type != D3D12_HEAP_TYPE_CUSTOM)
             {
                 D3D12MA_Budget budget = default;
-                m_hAllocator->GetBudgetForHeapType(&budget, m_HeapType);
+                m_hAllocator->GetBudgetForHeapType(&budget, m_HeapProps.Type);
                 freeMemory = (budget.UsageBytes < budget.BudgetBytes) ? (budget.BudgetBytes - budget.UsageBytes) : 0;
             }
 
@@ -651,7 +654,10 @@ namespace TerraFX.Interop
                 (*pAllocation)->InitPlaced(currRequest.offset, alignment, pBlock);
 
                 D3D12MA_HEAVY_ASSERT((D3D12MA_DEBUG_LEVEL > 1) && pBlock->Validate());
-                m_hAllocator->m_Budget.AddAllocation(HeapTypeToIndex(m_HeapType), size);
+                if (m_HeapProps.Type != D3D12_HEAP_TYPE_CUSTOM)
+                {
+                    m_hAllocator->m_Budget.AddAllocation(HeapTypeToIndex(m_HeapProps.Type), size);
+                }
 
                 return S_OK;
             }
@@ -668,7 +674,7 @@ namespace TerraFX.Interop
                 ref *pBlock,
                 m_hAllocator,
                 ref this,
-                m_HeapType,
+                (D3D12_HEAP_PROPERTIES*)Unsafe.AsPointer(ref m_HeapProps),
                 m_HeapFlags,
                 blockSize,
                 m_NextBlockId++

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_BlockVector.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_BlockVector.cs
@@ -144,7 +144,7 @@ namespace TerraFX.Interop
             D3D12MA_NormalBlock* pBlockToDelete = null;
 
             bool budgetExceeded = false;
-            if (m_HeapProps.Type != D3D12_HEAP_TYPE_CUSTOM)
+            if (IsHeapTypeStandard(m_HeapProps.Type))
             {
                 D3D12MA_Budget budget = default;
                 m_hAllocator->GetBudgetForHeapType(&budget, m_HeapProps.Type);
@@ -519,7 +519,7 @@ namespace TerraFX.Interop
             }
 
             ulong freeMemory = UINT64_MAX;
-            if (m_HeapProps.Type != D3D12_HEAP_TYPE_CUSTOM)
+            if (IsHeapTypeStandard(m_HeapProps.Type))
             {
                 D3D12MA_Budget budget = default;
                 m_hAllocator->GetBudgetForHeapType(&budget, m_HeapProps.Type);
@@ -649,16 +649,10 @@ namespace TerraFX.Interop
                 }
 
                 *pAllocation = m_hAllocator->GetAllocationObjectAllocator()->Allocate(m_hAllocator, size, currRequest.zeroInitialized);
-
                 pBlock->m_pMetadata->Alloc(&currRequest, size, *pAllocation);
                 (*pAllocation)->InitPlaced(currRequest.offset, alignment, pBlock);
-
                 D3D12MA_HEAVY_ASSERT((D3D12MA_DEBUG_LEVEL > 1) && pBlock->Validate());
-                if (m_HeapProps.Type != D3D12_HEAP_TYPE_CUSTOM)
-                {
-                    m_hAllocator->m_Budget.AddAllocation(HeapTypeToIndex(m_HeapProps.Type), size);
-                }
-
+                m_hAllocator->m_Budget.AddAllocation(HeapTypeToIndex(m_HeapProps.Type), size);
                 return S_OK;
             }
 

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CurrentBudgetData.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CurrentBudgetData.cs
@@ -3,10 +3,6 @@
 // Ported from D3D12MemAlloc.cpp in D3D12MemoryAllocator commit 5457bcdaee73ee1f3fe6027bbabf959119f88b3d
 // Original source is Copyright © Advanced Micro Devices, Inc. All rights reserved. Licensed under the MIT License (MIT).
 
-using System;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using static TerraFX.Interop.D3D12MemAlloc;
 
@@ -14,9 +10,9 @@ namespace TerraFX.Interop
 {
     internal unsafe struct D3D12MA_CurrentBudgetData
     {
-        public _D3D12MA_HEAP_TYPE_COUNT_e__FixedBuffer m_BlockBytes;
+        public fixed ulong m_BlockBytes[(int)D3D12MA_HEAP_TYPE_COUNT];
 
-        public _D3D12MA_HEAP_TYPE_COUNT_e__FixedBuffer m_AllocationBytes;
+        public fixed ulong m_AllocationBytes[(int)D3D12MA_HEAP_TYPE_COUNT];
 
         public volatile uint m_OperationsSinceBudgetFetch;
 
@@ -29,7 +25,7 @@ namespace TerraFX.Interop
         public ulong m_D3D12BudgetLocal, m_D3D12BudgetNonLocal;
 
         [NativeTypeName("UINT64")]
-        public _D3D12MA_HEAP_TYPE_COUNT_e__FixedBuffer m_BlockBytesAtBudgetFetch;
+        public fixed ulong m_BlockBytesAtBudgetFetch[(int)D3D12MA_HEAP_TYPE_COUNT];
 
         public static void _ctor(ref D3D12MA_CurrentBudgetData pThis)
         {
@@ -63,27 +59,6 @@ namespace TerraFX.Interop
             Volatile.Write(ref allocationBytes, Volatile.Read(ref allocationBytes) - allocationSize);
 
             ++m_OperationsSinceBudgetFetch;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public struct _D3D12MA_HEAP_TYPE_COUNT_e__FixedBuffer
-        {
-            public ulong e0;
-            public ulong e1;
-            public ulong e2;
-            public ulong e3;
-
-            public ref ulong this[int index]
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get
-                {
-                    return ref AsSpan()[index];
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public Span<ulong> AsSpan() => MemoryMarshal.CreateSpan(ref e0, (int)D3D12MA_HEAP_TYPE_COUNT);
         }
     }
 }

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CurrentBudgetData.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CurrentBudgetData.cs
@@ -71,6 +71,7 @@ namespace TerraFX.Interop
             public ulong e0;
             public ulong e1;
             public ulong e2;
+            public ulong e3;
 
             public ref ulong this[int index]
             {

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_NormalBlock.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_NormalBlock.cs
@@ -28,9 +28,9 @@ namespace TerraFX.Interop
 
         private D3D12MA_BlockVector* m_BlockVector;
 
-        public static void _ctor(ref D3D12MA_NormalBlock pThis, D3D12MA_AllocatorPimpl* allocator, ref D3D12MA_BlockVector blockVector, D3D12_HEAP_TYPE heapType, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong size, [NativeTypeName("UINT")] uint id)
+        public static void _ctor(ref D3D12MA_NormalBlock pThis, D3D12MA_AllocatorPimpl* allocator, ref D3D12MA_BlockVector blockVector, [NativeTypeName("const D3D12_HEAP_PROPERTIES&")] D3D12_HEAP_PROPERTIES* heapProps, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong size, [NativeTypeName("UINT")] uint id)
         {
-            pThis.Base = new D3D12MA_MemoryBlock(allocator, heapType, heapFlags, size, id);
+            pThis.Base = new D3D12MA_MemoryBlock(allocator, heapProps, heapFlags, size, id);
             pThis.Base.lpVtbl = Vtbl;
 
             pThis.m_pMetadata = null;
@@ -60,7 +60,8 @@ namespace TerraFX.Interop
             return hr;
         }
 
-        public readonly D3D12_HEAP_TYPE GetHeapType() => Base.GetHeapType();
+        [return: NativeTypeName("const D3D12_HEAP_PROPERTIES&")]
+        public readonly D3D12_HEAP_PROPERTIES* GetHeapProperties() => Base.GetHeapProperties();
 
         public readonly D3D12_HEAP_FLAGS GetHeapFlags() => Base.GetHeapFlags();
 

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_PoolPimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_PoolPimpl.cs
@@ -36,7 +36,7 @@ namespace TerraFX.Interop
             pThis.m_BlockVector = D3D12MA_NEW<D3D12MA_BlockVector>(allocator->GetAllocs());
             D3D12MA_BlockVector._ctor(
                 ref *pThis.m_BlockVector,
-                allocator, desc->HeapType, heapFlags,
+                allocator, &desc->HeapProperties, heapFlags,
                 preferredBlockSize,
                 desc->MinBlockCount, maxBlockCount,
                 explicitBlockSize

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
@@ -16,6 +16,7 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class D3D12MemAlloc
     {
+        internal const uint D3D12MA_DEFAULT_POOL_HEAP_TYPE_COUNT = 3; // Only DEFAULT, UPLOAD, READBACK.
         internal const uint D3D12MA_DEFAULT_POOL_MAX_COUNT = 9;
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -379,6 +380,11 @@ namespace TerraFX.Interop
                     return 2;
                 }
 
+                case D3D12_HEAP_TYPE_CUSTOM:
+                {
+                    return 3;
+                }
+
                 default:
                 {
                     D3D12MA_ASSERT(false);
@@ -391,7 +397,8 @@ namespace TerraFX.Interop
         {
             "DEFAULT",
             "UPLOAD",
-            "READBACK"
+            "READBACK",
+            "CUSTOM"
         };
 
         // Stat helper functions
@@ -737,11 +744,6 @@ namespace TerraFX.Interop
         {
             D3D12_HEAP_FLAGS result = D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES;
             return result;
-        }
-
-        internal static bool IsHeapTypeValid(D3D12_HEAP_TYPE type)
-        {
-            return type == D3D12_HEAP_TYPE_DEFAULT || type == D3D12_HEAP_TYPE_UPLOAD || type == D3D12_HEAP_TYPE_READBACK;
         }
 
         internal static void AddStatInfoToJson(D3D12MA_JsonWriter* json, D3D12MA_StatInfo* statInfo)

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
@@ -16,7 +16,7 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class D3D12MemAlloc
     {
-        internal const uint D3D12MA_DEFAULT_POOL_HEAP_TYPE_COUNT = 3; // Only DEFAULT, UPLOAD, READBACK.
+        internal const uint D3D12MA_STANDARD_HEAP_TYPE_COUNT = 3; // Only DEFAULT, UPLOAD, READBACK.
         internal const uint D3D12MA_DEFAULT_POOL_MAX_COUNT = 9;
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -744,6 +744,13 @@ namespace TerraFX.Interop
         {
             D3D12_HEAP_FLAGS result = D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES;
             return result;
+        }
+
+        internal static bool IsHeapTypeStandard(D3D12_HEAP_TYPE type)
+        {
+            return type == D3D12_HEAP_TYPE_DEFAULT ||
+                type == D3D12_HEAP_TYPE_UPLOAD ||
+                type == D3D12_HEAP_TYPE_READBACK;
         }
 
         internal static void AddStatInfoToJson(D3D12MA_JsonWriter* json, D3D12MA_StatInfo* statInfo)

--- a/tests/Interop/D3D12MemoryAllocator/src/Tests/D3D12MemAllocTests.cs
+++ b/tests/Interop/D3D12MemoryAllocator/src/Tests/D3D12MemAllocTests.cs
@@ -670,7 +670,7 @@ namespace TerraFX.Interop.UnitTests
             // # Create pool, 1..2 blocks of 11 MB
 
             D3D12MA_POOL_DESC poolDesc = default;
-            poolDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+            poolDesc.HeapProperties.Type = D3D12_HEAP_TYPE_DEFAULT;
             poolDesc.HeapFlags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
             poolDesc.BlockSize = 11 * MEGABYTE;
             poolDesc.MinBlockCount = 1;


### PR DESCRIPTION
Port of the support for custom heaps, see https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/issues/11#issuecomment-795468936.

This PR contains the following commits from D3D12MA:
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/ae6c3ab6c47505de5da31fd3168cfa5c178ce48c
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/ac9ad240900f8878ef9edac5fa37bb1a0953fc44