### PR TITLE
Inline Pimpl types

### DIFF
--- a/sources/Interop/D3D12MemoryAllocator/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/D3D12MemAlloc.cs
@@ -55,22 +55,19 @@ namespace TerraFX.Interop
                 (typeof(T) == typeof(D3D12MA_BlockMetadata_Generic)) ||
                 (typeof(T) == typeof(D3D12MA_PoolAllocator<D3D12MA_Allocation>.Item)) ||
                 (typeof(T) == typeof(D3D12MA_PoolAllocator<D3D12MA_List<D3D12MA_Suballocation>.Item>.Item)) ||
-                (typeof(T) == typeof(D3D12MA_VirtualBlockPimpl)) ||
+                (typeof(T) == typeof(D3D12MA_VirtualBlock)) ||
                 (typeof(T) == typeof(D3D12MA_Pool)))
             {
                 return 8;
             }
 
-            if ((typeof(T) == typeof(D3D12MA_Allocator)) ||
-                (typeof(T) == typeof(D3D12MA_Vector<Pointer<D3D12MA_Allocation>>)) ||
+            if ((typeof(T) == typeof(D3D12MA_Vector<Pointer<D3D12MA_Allocation>>)) ||
                 (typeof(T) == typeof(D3D12MA_Vector<Pointer<D3D12MA_Pool>>)) ||
                 (typeof(T) == typeof(D3D12MA_PoolAllocator<D3D12MA_Allocation>.ItemBlock)) ||
                 (typeof(T) == typeof(D3D12MA_PoolAllocator<D3D12MA_List<D3D12MA_Suballocation>.Item>.ItemBlock)) ||
                 (typeof(T) == typeof(D3D12MA_List<D3D12MA_Suballocation>.iterator)) ||
                 (typeof(T) == typeof(Pointer<D3D12MA_NormalBlock>)) ||
                 (typeof(T) == typeof(Pointer<D3D12MA_Allocation>)) ||
-                (typeof(T) == typeof(D3D12MA_VirtualBlock)) ||
-                (typeof(T) == typeof(D3D12MA_Pool)) ||
                 (typeof(T) == typeof(Pointer<D3D12MA_Pool>)))
             {
                 return (nuint)sizeof(void*);

--- a/sources/Interop/D3D12MemoryAllocator/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/D3D12MemAlloc.cs
@@ -56,7 +56,7 @@ namespace TerraFX.Interop
                 (typeof(T) == typeof(D3D12MA_PoolAllocator<D3D12MA_Allocation>.Item)) ||
                 (typeof(T) == typeof(D3D12MA_PoolAllocator<D3D12MA_List<D3D12MA_Suballocation>.Item>.Item)) ||
                 (typeof(T) == typeof(D3D12MA_VirtualBlockPimpl)) ||
-                (typeof(T) == typeof(D3D12MA_PoolPimpl)))
+                (typeof(T) == typeof(D3D12MA_Pool)))
             {
                 return 8;
             }

--- a/sources/Interop/D3D12MemoryAllocator/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/D3D12MemAlloc.cs
@@ -2,13 +2,6 @@
 
 using System;
 using System.Runtime.CompilerServices;
-using static TerraFX.Interop.D3D12_HEAP_TYPE;
-using static TerraFX.Interop.D3D12_HEAP_FLAGS;
-using static TerraFX.Interop.DXGI_FORMAT;
-using static TerraFX.Interop.D3D12_RESOURCE_DIMENSION;
-using static TerraFX.Interop.D3D12_RESOURCE_FLAGS;
-using static TerraFX.Interop.Windows;
-using static TerraFX.Interop.D3D12MemAlloc;
 
 namespace TerraFX.Interop
 {
@@ -56,7 +49,7 @@ namespace TerraFX.Interop
             }
 
             if ((typeof(T) == typeof(D3D12MA_Allocation)) ||
-                (typeof(T) == typeof(D3D12MA_AllocatorPimpl)) ||
+                (typeof(T) == typeof(D3D12MA_Allocator)) ||
                 (typeof(T) == typeof(D3D12MA_BlockVector)) ||
                 (typeof(T) == typeof(D3D12MA_NormalBlock)) ||
                 (typeof(T) == typeof(D3D12MA_BlockMetadata_Generic)) ||

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocation.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocation.cs
@@ -24,7 +24,7 @@ namespace TerraFX.Interop
     /// </summary>
     public unsafe struct D3D12MA_Allocation : IDisposable, D3D12MA_IItemTypeTraits<D3D12MA_Allocation>
     {
-        internal D3D12MA_AllocatorPimpl* m_Allocator;
+        internal D3D12MA_Allocator* m_Allocator;
 
         [NativeTypeName("UINT64")]
         internal ulong m_Size;
@@ -355,7 +355,7 @@ namespace TerraFX.Interop
             }
         }
 
-        internal static void _ctor(ref D3D12MA_Allocation pThis, D3D12MA_AllocatorPimpl* allocator, [NativeTypeName("UINT64")] ulong size, [NativeTypeName("BOOL")] int wasZeroInitialized)
+        internal static void _ctor(ref D3D12MA_Allocation pThis, D3D12MA_Allocator* allocator, [NativeTypeName("UINT64")] ulong size, [NativeTypeName("BOOL")] int wasZeroInitialized)
         {
             pThis.m_Allocator = allocator;
             pThis.m_Size = size;

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
@@ -24,7 +24,7 @@ namespace TerraFX.Interop
     /// right after Direct3D 12 is initialized and keep it alive until before Direct3D device is destroyed.
     /// </para>
     /// </summary>
-    public unsafe partial struct D3D12MA_Allocator
+    public unsafe partial struct D3D12MA_Allocator : IDisposable
     {
         /// <summary>
         /// Deletes this object.
@@ -121,7 +121,7 @@ namespace TerraFX.Interop
             }
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            return CreateResource_Pimpl(pAllocDesc, pResourceDesc, InitialResourceState, pOptimizedClearValue, ppAllocation, riidResource, ppvResource);
+            return CreateResourcePimpl(pAllocDesc, pResourceDesc, InitialResourceState, pOptimizedClearValue, ppAllocation, riidResource, ppvResource);
         }
 
         /// <summary>
@@ -274,7 +274,7 @@ namespace TerraFX.Interop
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
 
             *ppPool = D3D12MA_NEW<D3D12MA_Pool>(GetAllocs());
-            D3D12MA_Pool._ctor(ref **ppPool, (D3D12MA_Allocator*)Unsafe.AsPointer(ref this), pPoolDesc);
+            D3D12MA_Pool._ctor(ref **ppPool, ref this, pPoolDesc);
 
             HRESULT hr = (*ppPool)->Init();
 

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
@@ -24,7 +24,7 @@ namespace TerraFX.Interop
     /// right after Direct3D 12 is initialized and keep it alive until before Direct3D device is destroyed.
     /// </para>
     /// </summary>
-    public unsafe partial struct D3D12MA_Allocator : IDisposable
+    public unsafe partial struct D3D12MA_Allocator
     {
         /// <summary>
         /// Deletes this object.
@@ -274,9 +274,9 @@ namespace TerraFX.Interop
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
 
             *ppPool = D3D12MA_NEW<D3D12MA_Pool>(GetAllocs());
-            D3D12MA_Pool._ctor(ref **ppPool, ref this, pPoolDesc);
+            D3D12MA_Pool._ctor(ref **ppPool, (D3D12MA_Allocator*)Unsafe.AsPointer(ref this), pPoolDesc);
 
-            HRESULT hr = (*ppPool)->m_Pimpl->Init();
+            HRESULT hr = (*ppPool)->Init();
 
             if (SUCCEEDED(hr))
             {

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
@@ -24,10 +24,8 @@ namespace TerraFX.Interop
     /// right after Direct3D 12 is initialized and keep it alive until before Direct3D device is destroyed.
     /// </para>
     /// </summary>
-    public unsafe struct D3D12MA_Allocator : IDisposable
+    public unsafe partial struct D3D12MA_Allocator : IDisposable
     {
-        internal D3D12MA_AllocatorPimpl* m_Pimpl;
-
         /// <summary>
         /// Deletes this object.
         /// <para>
@@ -40,7 +38,7 @@ namespace TerraFX.Interop
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
 
             // Copy is needed because otherwise we would call destructor and invalidate the structure with callbacks before using it to free memory.
-            D3D12MA_ALLOCATION_CALLBACKS allocationCallbacksCopy = *m_Pimpl->GetAllocs();
+            D3D12MA_ALLOCATION_CALLBACKS allocationCallbacksCopy = *GetAllocs();
             D3D12MA_DELETE(&allocationCallbacksCopy, ref this);
         }
 
@@ -49,7 +47,7 @@ namespace TerraFX.Interop
         [return: NativeTypeName("const D3D12_FEATURE_DATA_D3D12_OPTIONS&")]
         public readonly D3D12_FEATURE_DATA_D3D12_OPTIONS* GetD3D12Options()
         {
-            return m_Pimpl->GetD3D12Options();
+            return (D3D12_FEATURE_DATA_D3D12_OPTIONS*)Unsafe.AsPointer(ref Unsafe.AsRef(in m_D3D12Options));
         }
 
         /// <summary>
@@ -65,7 +63,7 @@ namespace TerraFX.Interop
         [return: NativeTypeName("BOOL")]
         public readonly int IsUMA()
         {
-            return m_Pimpl->IsUMA();
+            return m_D3D12Architecture.UMA;
         }
 
         /// <summary>
@@ -81,7 +79,7 @@ namespace TerraFX.Interop
         [return: NativeTypeName("BOOL")]
         public readonly int IsCacheCoherentUMA()
         {
-            return m_Pimpl->IsCacheCoherentUMA();
+            return m_D3D12Architecture.CacheCoherentUMA;
         }
 
         /// <summary>
@@ -123,7 +121,7 @@ namespace TerraFX.Interop
             }
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            return m_Pimpl->CreateResource(pAllocDesc, pResourceDesc, InitialResourceState, pOptimizedClearValue, ppAllocation, riidResource, ppvResource);
+            return CreateResource_Pimpl(pAllocDesc, pResourceDesc, InitialResourceState, pOptimizedClearValue, ppAllocation, riidResource, ppvResource);
         }
 
         /// <summary>
@@ -141,7 +139,7 @@ namespace TerraFX.Interop
             }
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            return m_Pimpl->CreateResource1(pAllocDesc, pResourceDesc, InitialResourceState, pOptimizedClearValue, pProtectedSession, ppAllocation, riidResource, ppvResource);
+            return CreateResource1Pimpl(pAllocDesc, pResourceDesc, InitialResourceState, pOptimizedClearValue, pProtectedSession, ppAllocation, riidResource, ppvResource);
         }
 
         /// <summary>
@@ -167,7 +165,7 @@ namespace TerraFX.Interop
             }
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            return m_Pimpl->CreateResource2(pAllocDesc, pResourceDesc, InitialResourceState, pOptimizedClearValue, pProtectedSession, ppAllocation, riidResource, ppvResource);
+            return CreateResource2Pimpl(pAllocDesc, pResourceDesc, InitialResourceState, pOptimizedClearValue, pProtectedSession, ppAllocation, riidResource, ppvResource);
         }
 
         /// <summary>
@@ -196,7 +194,7 @@ namespace TerraFX.Interop
             }
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            return m_Pimpl->AllocateMemory(pAllocDesc, pAllocInfo, ppAllocation);
+            return AllocateMemoryPimpl(pAllocDesc, pAllocInfo, ppAllocation);
         }
 
         /// <summary>
@@ -214,7 +212,7 @@ namespace TerraFX.Interop
             }
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            return m_Pimpl->AllocateMemory1(pAllocDesc, pAllocInfo, pProtectedSession, ppAllocation);
+            return AllocateMemory1Pimpl(pAllocDesc, pAllocInfo, pProtectedSession, ppAllocation);
         }
 
         /// <summary>Creates a new resource in place of an existing allocation. This is useful for memory aliasing.</summary>
@@ -254,7 +252,7 @@ namespace TerraFX.Interop
             }
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            return m_Pimpl->CreateAliasingResource(pAllocation, AllocationLocalOffset, pResourceDesc, InitialResourceState, pOptimizedClearValue, riidResource, ppvResource);
+            return CreateAliasingResourcePimpl(pAllocation, AllocationLocalOffset, pResourceDesc, InitialResourceState, pOptimizedClearValue, riidResource, ppvResource);
         }
 
         /// <summary>Creates custom pool.</summary>
@@ -267,7 +265,7 @@ namespace TerraFX.Interop
                 return E_INVALIDARG;
             }
 
-            if (!m_Pimpl->HeapFlagsFulfillResourceHeapTier(pPoolDesc->HeapFlags))
+            if (!HeapFlagsFulfillResourceHeapTier(pPoolDesc->HeapFlags))
             {
                 D3D12MA_ASSERT(false); // "Invalid pPoolDesc->HeapFlags passed to Allocator::CreatePool. Did you forget to handle ResourceHeapTier=1?"
                 return E_INVALIDARG;
@@ -275,18 +273,18 @@ namespace TerraFX.Interop
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
 
-            *ppPool = D3D12MA_NEW<D3D12MA_Pool>(m_Pimpl->GetAllocs());
+            *ppPool = D3D12MA_NEW<D3D12MA_Pool>(GetAllocs());
             D3D12MA_Pool._ctor(ref **ppPool, ref this, pPoolDesc);
 
             HRESULT hr = (*ppPool)->m_Pimpl->Init();
 
             if (SUCCEEDED(hr))
             {
-                m_Pimpl->RegisterPool(*ppPool, pPoolDesc->HeapProperties.Type);
+                RegisterPool(*ppPool, pPoolDesc->HeapProperties.Type);
             }
             else
             {
-                D3D12MA_DELETE(m_Pimpl->GetAllocs(), *ppPool);
+                D3D12MA_DELETE(GetAllocs(), *ppPool);
                 *ppPool = null;
             }
 
@@ -305,7 +303,7 @@ namespace TerraFX.Interop
         public int SetDefaultHeapMinBytes(D3D12_HEAP_TYPE heapType, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong minBytes)
         {
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            return m_Pimpl->SetDefaultHeapMinBytes(heapType, heapFlags, minBytes);
+            return SetDefaultHeapMinBytesPimpl(heapType, heapFlags, minBytes);
         }
 
         /// <summary>
@@ -315,7 +313,7 @@ namespace TerraFX.Interop
         public void SetCurrentFrameIndex([NativeTypeName("UINT")] uint frameIndex)
         {
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            m_Pimpl->SetCurrentFrameIndex(frameIndex);
+            SetCurrentFrameIndexPimpl(frameIndex);
         }
 
         /// <summary>Retrieves statistics from the current state of the allocator.</summary>
@@ -323,7 +321,7 @@ namespace TerraFX.Interop
         {
             D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && (pStats != null));
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            m_Pimpl->CalculateStats(pStats);
+            CalculateStatsPimpl(pStats);
         }
 
         /// <summary>Retrieves information about current memory budget.</summary>
@@ -342,7 +340,7 @@ namespace TerraFX.Interop
             }
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            m_Pimpl->GetBudget(pGpuBudget, pCpuBudget);
+            GetBudgetPimpl(pGpuBudget, pCpuBudget);
         }
 
         /// <summary>Builds and returns statistics as a string in JSON format.</summary>
@@ -352,7 +350,7 @@ namespace TerraFX.Interop
         {
             D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && (ppStatsString != null));
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            m_Pimpl->BuildStatsString(ppStatsString, DetailedMap);
+            BuildStatsStringPimpl(ppStatsString, DetailedMap);
         }
 
         /// <summary>Frees memory of a string returned from <see cref="BuildStatsString"/>.</summary>
@@ -361,19 +359,8 @@ namespace TerraFX.Interop
             if (pStatsString != null)
             {
                 using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-                m_Pimpl->FreeStatsString(pStatsString);
+                FreeStatsStringPimpl(pStatsString);
             }
-        }
-
-        internal static void _ctor(ref D3D12MA_Allocator pThis, [NativeTypeName("const ALLOCATION_CALLBACKS&")] D3D12MA_ALLOCATION_CALLBACKS* allocationCallbacks, [NativeTypeName("const ALLOCATOR_DESC&")] D3D12MA_ALLOCATOR_DESC* desc)
-        {
-            pThis.m_Pimpl = D3D12MA_NEW<D3D12MA_AllocatorPimpl>(allocationCallbacks);
-            D3D12MA_AllocatorPimpl._ctor(ref *pThis.m_Pimpl, allocationCallbacks, desc);
-        }
-
-        void IDisposable.Dispose()
-        {
-            D3D12MA_DELETE(m_Pimpl->GetAllocs(), m_Pimpl);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
@@ -3,6 +3,7 @@
 // Ported from D3D12MemAlloc.h in D3D12MemoryAllocator commit 5457bcdaee73ee1f3fe6027bbabf959119f88b3d
 // Original source is Copyright © Advanced Micro Devices, Inc. All rights reserved. Licensed under the MIT License (MIT).
 
+using System;
 using static TerraFX.Interop.D3D12MemAlloc;
 
 namespace TerraFX.Interop
@@ -16,7 +17,7 @@ namespace TerraFX.Interop
     /// </para>
     /// <para>To create custom pool, fill <see cref="D3D12MA_POOL_DESC"/> and call <see cref="D3D12MA_Allocator.CreatePool"/>.</para>
     /// </summary>
-    public unsafe partial struct D3D12MA_Pool
+    public unsafe partial struct D3D12MA_Pool : IDisposable
     {
         /// <summary>
         /// Deletes pool object, frees D3D12 heaps (memory blocks) managed by it. Allocations and resources must already be released!

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
@@ -3,8 +3,6 @@
 // Ported from D3D12MemAlloc.h in D3D12MemoryAllocator commit 5457bcdaee73ee1f3fe6027bbabf959119f88b3d
 // Original source is Copyright © Advanced Micro Devices, Inc. All rights reserved. Licensed under the MIT License (MIT).
 
-using System;
-using System.Runtime.CompilerServices;
 using static TerraFX.Interop.D3D12MemAlloc;
 
 namespace TerraFX.Interop
@@ -18,33 +16,21 @@ namespace TerraFX.Interop
     /// </para>
     /// <para>To create custom pool, fill <see cref="D3D12MA_POOL_DESC"/> and call <see cref="D3D12MA_Allocator.CreatePool"/>.</para>
     /// </summary>
-    public unsafe struct D3D12MA_Pool : IDisposable
+    public unsafe partial struct D3D12MA_Pool
     {
-        internal D3D12MA_PoolPimpl* m_Pimpl;
-
         /// <summary>
         /// Deletes pool object, frees D3D12 heaps (memory blocks) managed by it. Allocations and resources must already be released!
         /// <para>It doesn't delete allocations and resources created in this pool. They must be all released before calling this function!</para>
         /// </summary>
         public void Release()
         {
-            if (Unsafe.IsNullRef(ref this))
-            {
-                return;
-            }
-
-            using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            D3D12MA_DELETE(m_Pimpl->GetAllocator()->GetAllocs(), ref this);
         }
 
         /// <summary>
         /// Returns copy of parameters of the pool.
         /// <para>These are the same parameters as passed to <see cref="D3D12MA_Allocator.CreatePool"/>.</para>
         /// </summary>
-        public readonly D3D12MA_POOL_DESC GetDesc()
-        {
-            return *m_Pimpl->GetDesc();
-        }
+        public readonly D3D12MA_POOL_DESC GetDesc() => m_Desc;
 
         /// <summary>
         /// Sets the minimum number of bytes that should always be allocated (reserved) in this pool.
@@ -53,7 +39,7 @@ namespace TerraFX.Interop
         [return: NativeTypeName("HRESULT")]
         public int SetMinBytes([NativeTypeName("UINT64")] ulong minBytes)
         {
-            return m_Pimpl->SetMinBytes(minBytes);
+            return SetMinBytesPimpl(minBytes);
         }
 
         /// <summary>Retrieves statistics from the current state of this pool.</summary>
@@ -61,7 +47,7 @@ namespace TerraFX.Interop
         {
             D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && (pStats != null));
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            m_Pimpl->CalculateStats(pStats);
+            CalculateStatsPimpl(pStats);
         }
 
         /// <summary>
@@ -72,7 +58,7 @@ namespace TerraFX.Interop
         public void SetName([NativeTypeName("LPCWSTR")] ushort* Name)
         {
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            m_Pimpl->SetName(Name);
+            SetNamePimpl(Name);
         }
 
         /// <summary>
@@ -81,21 +67,6 @@ namespace TerraFX.Interop
         /// <para>If no name was associated with the allocation, returns <see langword="null"/>.</para>
         /// </summary>
         [return: NativeTypeName("LPCWSTR")]
-        public ushort* GetName()
-        {
-            return m_Pimpl->GetName();
-        }
-
-        internal static void _ctor(ref D3D12MA_Pool pThis, ref D3D12MA_Allocator allocator, [NativeTypeName("const POOL_DESC&")] D3D12MA_POOL_DESC* desc)
-        {
-            pThis.m_Pimpl = D3D12MA_NEW<D3D12MA_PoolPimpl>(allocator.GetAllocs());
-            D3D12MA_PoolPimpl._ctor(ref *pThis.m_Pimpl, (D3D12MA_Allocator*)Unsafe.AsPointer(ref allocator), desc);
-        }
-
-        void IDisposable.Dispose()
-        {
-            m_Pimpl->GetAllocator()->UnregisterPool(ref this, m_Pimpl->GetDesc()->HeapProperties.Type);
-            D3D12MA_DELETE(m_Pimpl->GetAllocator()->GetAllocs(), m_Pimpl);
-        }
+        public ushort* GetName() => m_Name;
     }
 }

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
@@ -88,8 +88,8 @@ namespace TerraFX.Interop
 
         internal static void _ctor(ref D3D12MA_Pool pThis, ref D3D12MA_Allocator allocator, [NativeTypeName("const POOL_DESC&")] D3D12MA_POOL_DESC* desc)
         {
-            pThis.m_Pimpl = D3D12MA_NEW<D3D12MA_PoolPimpl>(allocator.m_Pimpl->GetAllocs());
-            D3D12MA_PoolPimpl._ctor(ref *pThis.m_Pimpl, allocator.m_Pimpl, desc);
+            pThis.m_Pimpl = D3D12MA_NEW<D3D12MA_PoolPimpl>(allocator.GetAllocs());
+            D3D12MA_PoolPimpl._ctor(ref *pThis.m_Pimpl, (D3D12MA_Allocator*)Unsafe.AsPointer(ref allocator), desc);
         }
 
         void IDisposable.Dispose()

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_VirtualBlock.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_VirtualBlock.cs
@@ -129,16 +129,16 @@ namespace TerraFX.Interop
 
             using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
 
-            using var sb = new D3D12MA_StringBuilder((D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref m_AllocationCallbacks));
+            using var sb = new D3D12MA_StringBuilder(ref m_AllocationCallbacks);
 
-            using (var json = new D3D12MA_JsonWriter((D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref m_AllocationCallbacks), &sb))
+            using (var json = new D3D12MA_JsonWriter(ref m_AllocationCallbacks, &sb))
             {
                 D3D12MA_HEAVY_ASSERT((D3D12MA_DEBUG_LEVEL > 1) && m_Metadata.Validate());
                 m_Metadata.WriteAllocationInfoToJson(&json);
             }
 
             nuint length = sb.GetLength();
-            ushort* result = AllocateArray<ushort>((D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref m_AllocationCallbacks), length + 1);
+            ushort* result = AllocateArray<ushort>(ref m_AllocationCallbacks, length + 1);
             memcpy(result, sb.GetData(), length * sizeof(ushort));
             result[length] = '\0';
             *ppStatsString = result;
@@ -150,7 +150,7 @@ namespace TerraFX.Interop
             if (pStatsString != null)
             {
                 using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-                Free((D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref m_AllocationCallbacks), pStatsString);
+                Free(ref m_AllocationCallbacks, pStatsString);
             }
         }
 

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_AllocationObjectAllocator.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_AllocationObjectAllocator.cs
@@ -21,7 +21,7 @@ namespace TerraFX.Interop
             D3D12MA_PoolAllocator<D3D12MA_Allocation>._ctor(ref pThis.m_Allocator, (D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref allocationCallbacks), 1024);
         }
 
-        public D3D12MA_Allocation* Allocate(D3D12MA_AllocatorPimpl* allocator, ulong size, int wasZeroInitialized)
+        public D3D12MA_Allocation* Allocate(D3D12MA_Allocator* allocator, ulong size, int wasZeroInitialized)
         {
             using var mutexLock = new D3D12MA_MutexLock(ref m_Mutex);
 

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
@@ -22,9 +22,9 @@ using System.Threading;
 
 namespace TerraFX.Interop
 {
-    internal unsafe struct D3D12MA_AllocatorPimpl : IDisposable
+    public unsafe partial struct D3D12MA_Allocator : IDisposable
     {
-        public D3D12MA_CurrentBudgetData m_Budget;
+        internal D3D12MA_CurrentBudgetData m_Budget;
 
 #pragma warning disable CS0649
         private bool m_UseMutex;
@@ -86,7 +86,7 @@ namespace TerraFX.Interop
         // Explicit constructor as a normal instance method: this is needed to ensure the code is executed in-place over the
         // AllocatorPimpl instance being initialized, and not on a local variable which is then copied over to the
         // target memory location, which would break the references to self fields being used in the code below.
-        internal static void _ctor(ref D3D12MA_AllocatorPimpl pThis, [NativeTypeName("const D3D12MA_ALLOCATION_CALLBACKS&")] D3D12MA_ALLOCATION_CALLBACKS* allocationCallbacks, [NativeTypeName("const D3D12MA_ALLOCATOR_DESC&")] D3D12MA_ALLOCATOR_DESC* desc)
+        internal static void _ctor(ref D3D12MA_Allocator pThis, [NativeTypeName("const D3D12MA_ALLOCATION_CALLBACKS&")] D3D12MA_ALLOCATION_CALLBACKS* allocationCallbacks, [NativeTypeName("const D3D12MA_ALLOCATOR_DESC&")] D3D12MA_ALLOCATOR_DESC* desc)
         {
             D3D12MA_CurrentBudgetData._ctor(ref pThis.m_Budget);
 
@@ -145,9 +145,9 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        public int Init(D3D12MA_ALLOCATOR_DESC* desc)
+        internal int Init(D3D12MA_ALLOCATOR_DESC* desc)
         {
-            D3D12MA_AllocatorPimpl* pThis = (D3D12MA_AllocatorPimpl*)Unsafe.AsPointer(ref this);
+            D3D12MA_Allocator* pThis = (D3D12MA_Allocator*)Unsafe.AsPointer(ref this);
 
             if (D3D12MA_DXGI_1_4 != 0)
             {
@@ -254,32 +254,23 @@ namespace TerraFX.Interop
             m_AllocationObjectAllocator.Dispose();
         }
 
-        public readonly ID3D12Device* GetDevice() => m_Device;
+        internal readonly ID3D12Device* GetDevice() => m_Device;
 
-        public readonly ID3D12Device4* GetDevice4() => m_Device4;
+        internal readonly ID3D12Device4* GetDevice4() => m_Device4;
 
-        public readonly ID3D12Device8* GetDevice8() => m_Device8;
+        internal readonly ID3D12Device8* GetDevice8() => m_Device8;
 
         // Shortcut for "Allocation Callbacks", because this function is called so often.
         [return: NativeTypeName("const D3D12MA_ALLOCATION_CALLBACKS&")]
-        public readonly D3D12MA_ALLOCATION_CALLBACKS* GetAllocs() => (D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref Unsafe.AsRef(in m_AllocationCallbacks));
+        internal readonly D3D12MA_ALLOCATION_CALLBACKS* GetAllocs() => (D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref Unsafe.AsRef(in m_AllocationCallbacks));
 
-        [return: NativeTypeName("const D3D12_FEATURE_DATA_D3D12_OPTIONS&")]
-        public readonly D3D12_FEATURE_DATA_D3D12_OPTIONS* GetD3D12Options() => (D3D12_FEATURE_DATA_D3D12_OPTIONS*)Unsafe.AsPointer(ref Unsafe.AsRef(in m_D3D12Options));
+        private readonly bool SupportsResourceHeapTier2() => m_D3D12Options.ResourceHeapTier >= D3D12_RESOURCE_HEAP_TIER_2;
 
-        [return: NativeTypeName("BOOL")]
-        public readonly int IsUMA() => m_D3D12Architecture.UMA;
+        internal readonly bool UseMutex() => m_UseMutex;
 
-        [return: NativeTypeName("BOOL")]
-        public readonly int IsCacheCoherentUMA() => m_D3D12Architecture.CacheCoherentUMA;
+        internal D3D12MA_AllocationObjectAllocator* GetAllocationObjectAllocator() => (D3D12MA_AllocationObjectAllocator*)Unsafe.AsPointer(ref m_AllocationObjectAllocator);
 
-        public readonly bool SupportsResourceHeapTier2() => m_D3D12Options.ResourceHeapTier >= D3D12_RESOURCE_HEAP_TIER_2;
-
-        public readonly bool UseMutex() => m_UseMutex;
-
-        public D3D12MA_AllocationObjectAllocator* GetAllocationObjectAllocator() => (D3D12MA_AllocationObjectAllocator*)Unsafe.AsPointer(ref m_AllocationObjectAllocator);
-
-        public readonly bool HeapFlagsFulfillResourceHeapTier(D3D12_HEAP_FLAGS flags)
+        private readonly bool HeapFlagsFulfillResourceHeapTier(D3D12_HEAP_FLAGS flags)
         {
             if (SupportsResourceHeapTier2())
             {
@@ -296,7 +287,7 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        public int CreateResource(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_DESC* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, D3D12_CLEAR_VALUE* pOptimizedClearValue, D3D12MA_Allocation** ppAllocation, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
+        private int CreateResource_Pimpl(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_DESC* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, D3D12_CLEAR_VALUE* pOptimizedClearValue, D3D12MA_Allocation** ppAllocation, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
         {
             *ppAllocation = null;
 
@@ -421,7 +412,7 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        public int CreateResource1(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_DESC* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, D3D12_CLEAR_VALUE* pOptimizedClearValue, ID3D12ProtectedResourceSession *pProtectedSession, D3D12MA_Allocation** ppAllocation, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
+        private int CreateResource1Pimpl(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_DESC* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, D3D12_CLEAR_VALUE* pOptimizedClearValue, ID3D12ProtectedResourceSession *pProtectedSession, D3D12MA_Allocation** ppAllocation, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
         {
             if (m_Device4 == null)
             {
@@ -469,7 +460,7 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        public int CreateResource2(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_DESC1* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, D3D12_CLEAR_VALUE* pOptimizedClearValue, ID3D12ProtectedResourceSession *pProtectedSession, D3D12MA_Allocation** ppAllocation, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
+        private int CreateResource2Pimpl(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_DESC1* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, D3D12_CLEAR_VALUE* pOptimizedClearValue, ID3D12ProtectedResourceSession *pProtectedSession, D3D12MA_Allocation** ppAllocation, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
         {
             *ppAllocation = null;
 
@@ -607,7 +598,7 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        public int AllocateMemory(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_ALLOCATION_INFO* pAllocInfo, D3D12MA_Allocation** ppAllocation)
+        private int AllocateMemoryPimpl(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_ALLOCATION_INFO* pAllocInfo, D3D12MA_Allocation** ppAllocation)
         {
             *ppAllocation = null;
 
@@ -679,7 +670,7 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        public int AllocateMemory1(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_ALLOCATION_INFO* pAllocInfo, ID3D12ProtectedResourceSession *pProtectedSession, D3D12MA_Allocation** ppAllocation)
+        private int AllocateMemory1Pimpl(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_ALLOCATION_INFO* pAllocInfo, ID3D12ProtectedResourceSession *pProtectedSession, D3D12MA_Allocation** ppAllocation)
         {
             if (m_Device4 == null)
             {
@@ -708,7 +699,7 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        public int CreateAliasingResource(D3D12MA_Allocation* pAllocation, [NativeTypeName("UINT64")] ulong AllocationLocalOffset, D3D12_RESOURCE_DESC* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, [NativeTypeName("const D3D12_CLEAR_VALUE&")] D3D12_CLEAR_VALUE* pOptimizedClearValue, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
+        private int CreateAliasingResourcePimpl(D3D12MA_Allocation* pAllocation, [NativeTypeName("UINT64")] ulong AllocationLocalOffset, D3D12_RESOURCE_DESC* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, [NativeTypeName("const D3D12_CLEAR_VALUE&")] D3D12_CLEAR_VALUE* pOptimizedClearValue, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
         {
             *ppvResource = null;
 
@@ -742,7 +733,7 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        public int SetDefaultHeapMinBytes(D3D12_HEAP_TYPE heapType, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong minBytes)
+        private int SetDefaultHeapMinBytesPimpl(D3D12_HEAP_TYPE heapType, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong minBytes)
         {
             if (!IsHeapTypeStandard(heapType))
             {
@@ -807,12 +798,12 @@ namespace TerraFX.Interop
         /// Unregisters allocation from the collection of dedicated allocations.
         /// Allocation object must be deleted externally afterwards.
         /// </summary>
-        public void FreeCommittedMemory([NativeTypeName("Allocation*")] ref D3D12MA_Allocation allocation)
+        internal void FreeCommittedMemory([NativeTypeName("Allocation*")] ref D3D12MA_Allocation allocation)
         {
             FreeCommittedMemory((D3D12MA_Allocation*)Unsafe.AsPointer(ref allocation));
         }
 
-        public void FreeCommittedMemory([NativeTypeName("Allocation*")] D3D12MA_Allocation* allocation)
+        private void FreeCommittedMemory([NativeTypeName("Allocation*")] D3D12MA_Allocation* allocation)
         {
             D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && (allocation != null) && (allocation->m_PackedData.GetType() == D3D12MA_Allocation.Type.TYPE_COMMITTED));
             UnregisterCommittedAllocation(allocation, allocation->m_Committed.heapType);
@@ -829,12 +820,12 @@ namespace TerraFX.Interop
         /// Unregisters allocation from the collection of placed allocations.
         /// Allocation object must be deleted externally afterwards.
         /// </summary>
-        public void FreePlacedMemory([NativeTypeName("Allocation*")] ref D3D12MA_Allocation allocation)
+        internal void FreePlacedMemory([NativeTypeName("Allocation*")] ref D3D12MA_Allocation allocation)
         {
             FreePlacedMemory((D3D12MA_Allocation*)Unsafe.AsPointer(ref allocation));
         }
 
-        public void FreePlacedMemory([NativeTypeName("Allocation*")] D3D12MA_Allocation* allocation)
+        private void FreePlacedMemory([NativeTypeName("Allocation*")] D3D12MA_Allocation* allocation)
         {
             D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && allocation != null && allocation->m_PackedData.GetType() == D3D12MA_Allocation.Type.TYPE_PLACED);
             D3D12MA_NormalBlock* block = allocation->m_Placed.block;
@@ -852,12 +843,12 @@ namespace TerraFX.Interop
         /// Unregisters allocation from the collection of dedicated allocations and destroys associated heap.
         /// Allocation object must be deleted externally afterwards.
         /// </summary>
-        public void FreeHeapMemory([NativeTypeName("Allocation*")] ref D3D12MA_Allocation allocation)
+        internal void FreeHeapMemory([NativeTypeName("Allocation*")] ref D3D12MA_Allocation allocation)
         {
             FreeHeapMemory((D3D12MA_Allocation*)Unsafe.AsPointer(ref allocation));
         }
 
-        public void FreeHeapMemory([NativeTypeName("Allocation*")] D3D12MA_Allocation* allocation)
+        private void FreeHeapMemory([NativeTypeName("Allocation*")] D3D12MA_Allocation* allocation)
         {
             D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && allocation != null && allocation->m_PackedData.GetType() == D3D12MA_Allocation.Type.TYPE_HEAP);
             UnregisterCommittedAllocation(allocation, allocation->m_Heap.heapType);
@@ -872,7 +863,7 @@ namespace TerraFX.Interop
             m_Budget.RemoveAllocation(heapTypeIndex, allocationSize);
         }
 
-        public void SetCurrentFrameIndex([NativeTypeName("UINT")] uint frameIndex)
+        private void SetCurrentFrameIndexPimpl([NativeTypeName("UINT")] uint frameIndex)
         {
             m_CurrentFrameIndex = frameIndex;
 
@@ -883,9 +874,9 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("UINT")]
-        public readonly uint GetCurrentFrameIndex() => m_CurrentFrameIndex;
+        internal readonly uint GetCurrentFrameIndex() => m_CurrentFrameIndex;
 
-        public void CalculateStats(D3D12MA_Stats* outStats)
+        private void CalculateStatsPimpl(D3D12MA_Stats* outStats)
         {
             // Init stats
             ZeroMemory(outStats, (uint)sizeof(D3D12MA_Stats));
@@ -971,7 +962,7 @@ namespace TerraFX.Interop
                 PostProcessStatInfo(ref outStats->HeapType[(int)i]);
         }
 
-        public void GetBudget(D3D12MA_Budget* outGpuBudget, D3D12MA_Budget* outCpuBudget)
+        private void GetBudgetPimpl(D3D12MA_Budget* outGpuBudget, D3D12MA_Budget* outCpuBudget)
         {
             if (outGpuBudget != null)
             {
@@ -1049,7 +1040,7 @@ namespace TerraFX.Interop
             }
         }
 
-        public void GetBudgetForHeapType(D3D12MA_Budget* outBudget, D3D12_HEAP_TYPE heapType)
+        internal void GetBudgetForHeapType(D3D12MA_Budget* outBudget, D3D12_HEAP_TYPE heapType)
         {
             switch (heapType)
             {
@@ -1074,7 +1065,7 @@ namespace TerraFX.Interop
             }
         }
 
-        public void BuildStatsString([NativeTypeName("WCHAR**")] ushort** ppStatsString, [NativeTypeName("BOOL")] int DetailedMap)
+        private void BuildStatsStringPimpl([NativeTypeName("WCHAR**")] ushort** ppStatsString, [NativeTypeName("BOOL")] int DetailedMap)
         {
             using var sb = new D3D12MA_StringBuilder(GetAllocs());
 
@@ -1197,7 +1188,7 @@ namespace TerraFX.Interop
             *ppStatsString = result;
         }
 
-        public void FreeStatsString([NativeTypeName("WCHAR*")] ushort* pStatsString)
+        private void FreeStatsStringPimpl([NativeTypeName("WCHAR*")] ushort* pStatsString)
         {
             D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && (pStatsString != null));
             Free(GetAllocs(), pStatsString);
@@ -1207,7 +1198,7 @@ namespace TerraFX.Interop
         /// Heuristics that decides whether a resource should better be placed in its own,
         /// dedicated allocation(committed resource rather than placed resource).
         /// </summary>
-        internal static bool PrefersCommittedAllocation<TD3D12_RESOURCE_DESC>(TD3D12_RESOURCE_DESC* resourceDesc)
+        private static bool PrefersCommittedAllocation<TD3D12_RESOURCE_DESC>(TD3D12_RESOURCE_DESC* resourceDesc)
             where TD3D12_RESOURCE_DESC : unmanaged
         {
             // Intentional. It may change in the future.
@@ -1248,7 +1239,7 @@ namespace TerraFX.Interop
                 if (SUCCEEDED(hr))
                 {
                     const int wasZeroInitialized = 1;
-                    D3D12MA_Allocation* alloc = m_AllocationObjectAllocator.Allocate((D3D12MA_AllocatorPimpl*)Unsafe.AsPointer(ref this), resAllocInfo->SizeInBytes, wasZeroInitialized);
+                    D3D12MA_Allocation* alloc = m_AllocationObjectAllocator.Allocate((D3D12MA_Allocator*)Unsafe.AsPointer(ref this), resAllocInfo->SizeInBytes, wasZeroInitialized);
                     alloc->InitCommitted(pAllocDesc->HeapType);
                     alloc->SetResource(res, pResourceDesc);
 
@@ -1309,7 +1300,7 @@ namespace TerraFX.Interop
                 if (SUCCEEDED(hr))
                 {
                     const int wasZeroInitialized = 1;
-                    D3D12MA_Allocation* alloc = m_AllocationObjectAllocator.Allocate((D3D12MA_AllocatorPimpl*)Unsafe.AsPointer(ref this), resAllocInfo->SizeInBytes, wasZeroInitialized);
+                    D3D12MA_Allocation* alloc = m_AllocationObjectAllocator.Allocate((D3D12MA_Allocator*)Unsafe.AsPointer(ref this), resAllocInfo->SizeInBytes, wasZeroInitialized);
                     alloc->InitCommitted(pAllocDesc->HeapType);
                     alloc->SetResource(res, pResourceDesc);
 
@@ -1368,7 +1359,7 @@ namespace TerraFX.Interop
                 if (SUCCEEDED(hr))
                 {
                     const int wasZeroInitialized = 1;
-                    D3D12MA_Allocation* alloc = m_AllocationObjectAllocator.Allocate((D3D12MA_AllocatorPimpl*)Unsafe.AsPointer(ref this), resAllocInfo->SizeInBytes, wasZeroInitialized);
+                    D3D12MA_Allocation* alloc = m_AllocationObjectAllocator.Allocate((D3D12MA_Allocator*)Unsafe.AsPointer(ref this), resAllocInfo->SizeInBytes, wasZeroInitialized);
 
                     alloc->InitCommitted(pAllocDesc->HeapType);
                     alloc->SetResource(res, pResourceDesc);
@@ -1423,7 +1414,7 @@ namespace TerraFX.Interop
             if (SUCCEEDED(hr))
             {
                 const int wasZeroInitialized = 1;
-                *ppAllocation = m_AllocationObjectAllocator.Allocate((D3D12MA_AllocatorPimpl*)Unsafe.AsPointer(ref this), allocInfo->SizeInBytes, wasZeroInitialized);
+                *ppAllocation = m_AllocationObjectAllocator.Allocate((D3D12MA_Allocator*)Unsafe.AsPointer(ref this), allocInfo->SizeInBytes, wasZeroInitialized);
                 (*ppAllocation)->InitHeap(pAllocDesc->HeapType, heap);
                 RegisterCommittedAllocation(*ppAllocation, pAllocDesc->HeapType);
 
@@ -1471,7 +1462,7 @@ namespace TerraFX.Interop
             if (SUCCEEDED(hr))
             {
                 const int wasZeroInitialized = 1;
-                *ppAllocation = m_AllocationObjectAllocator.Allocate((D3D12MA_AllocatorPimpl*)Unsafe.AsPointer(ref this), allocInfo->SizeInBytes, wasZeroInitialized);
+                *ppAllocation = m_AllocationObjectAllocator.Allocate((D3D12MA_Allocator*)Unsafe.AsPointer(ref this), allocInfo->SizeInBytes, wasZeroInitialized);
                 (*ppAllocation)->InitHeap(pAllocDesc->HeapType, heap);
                 RegisterCommittedAllocation(*ppAllocation, pAllocDesc->HeapType);
 
@@ -1744,7 +1735,7 @@ namespace TerraFX.Interop
         }
 
         /// <summary>Registers Pool object in m_pPools.</summary>
-        internal void RegisterPool(D3D12MA_Pool* pool, D3D12_HEAP_TYPE heapType)
+        private void RegisterPool(D3D12MA_Pool* pool, D3D12_HEAP_TYPE heapType)
         {
             uint heapTypeIndex = HeapTypeToIndex(heapType);
 
@@ -1759,7 +1750,7 @@ namespace TerraFX.Interop
             UnregisterPool((D3D12MA_Pool*)Unsafe.AsPointer(ref pool), heapType);
         }
 
-        internal void UnregisterPool([NativeTypeName("Pool*")] D3D12MA_Pool* pool, D3D12_HEAP_TYPE heapType)
+        private void UnregisterPool([NativeTypeName("Pool*")] D3D12MA_Pool* pool, D3D12_HEAP_TYPE heapType)
         {
             uint heapTypeIndex = HeapTypeToIndex(heapType);
 
@@ -1905,15 +1896,15 @@ namespace TerraFX.Interop
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public struct _D3D12MA_HEAP_TYPE_COUNT_e__FixedBuffer<T>
+        internal struct _D3D12MA_HEAP_TYPE_COUNT_e__FixedBuffer<T>
             where T : unmanaged
         {
-            public T e0;
-            public T e1;
-            public T e2;
-            public T e3;
+            internal T e0;
+            internal T e1;
+            internal T e2;
+            internal T e3;
 
-            public ref T this[int index]
+            internal ref T this[int index]
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
@@ -1923,24 +1914,24 @@ namespace TerraFX.Interop
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref e0, (int)D3D12MA_HEAP_TYPE_COUNT);
+            internal Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref e0, (int)D3D12MA_HEAP_TYPE_COUNT);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public struct _D3D12MA_DEFAULT_POOL_MAX_COUNT_e__FixedBuffer<T>
+        internal struct _D3D12MA_DEFAULT_POOL_MAX_COUNT_e__FixedBuffer<T>
             where T : unmanaged
         {
-            public T e0;
-            public T e1;
-            public T e2;
-            public T e3;
-            public T e4;
-            public T e5;
-            public T e6;
-            public T e7;
-            public T e8;
+            internal T e0;
+            internal T e1;
+            internal T e2;
+            internal T e3;
+            internal T e4;
+            internal T e5;
+            internal T e6;
+            internal T e7;
+            internal T e8;
 
-            public ref T this[int index]
+            internal ref T this[int index]
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
@@ -1950,7 +1941,7 @@ namespace TerraFX.Interop
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref e0, (int)D3D12MA_DEFAULT_POOL_MAX_COUNT);
+            internal Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref e0, (int)D3D12MA_DEFAULT_POOL_MAX_COUNT);
         }
     }
 }

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
@@ -22,7 +22,7 @@ using System.Threading;
 
 namespace TerraFX.Interop
 {
-    public unsafe partial struct D3D12MA_Allocator : IDisposable
+    public unsafe partial struct D3D12MA_Allocator
     {
         internal D3D12MA_CurrentBudgetData m_Budget;
 
@@ -72,7 +72,7 @@ namespace TerraFX.Interop
 
         // Default pools.
         [NativeTypeName("BlockVector* m_BlockVectors[DEFAULT_POOL_MAX_COUNT]")]
-        internal _D3D12MA_DEFAULT_POOL_MAX_COUNT_e__FixedBuffer<Pointer<D3D12MA_BlockVector>> m_BlockVectors;
+        private _D3D12MA_DEFAULT_POOL_MAX_COUNT_e__FixedBuffer<Pointer<D3D12MA_BlockVector>> m_BlockVectors;
 
         // # Used only when ResourceHeapTier = 1
         [NativeTypeName("UINT64 m_DefaultPoolTier1MinBytes[DEFAULT_POOL_MAX_COUNT]")]
@@ -287,7 +287,7 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        private int CreateResource_Pimpl(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_DESC* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, D3D12_CLEAR_VALUE* pOptimizedClearValue, D3D12MA_Allocation** ppAllocation, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
+        private int CreateResourcePimpl(D3D12MA_ALLOCATION_DESC* pAllocDesc, D3D12_RESOURCE_DESC* pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, D3D12_CLEAR_VALUE* pOptimizedClearValue, D3D12MA_Allocation** ppAllocation, [NativeTypeName("REFIID")] Guid* riidResource, void** ppvResource)
         {
             *ppAllocation = null;
 
@@ -1896,15 +1896,17 @@ namespace TerraFX.Interop
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal struct _D3D12MA_HEAP_TYPE_COUNT_e__FixedBuffer<T>
+        private struct _D3D12MA_HEAP_TYPE_COUNT_e__FixedBuffer<T>
             where T : unmanaged
         {
-            internal T e0;
-            internal T e1;
-            internal T e2;
-            internal T e3;
+#pragma warning disable CS0649
+            public T e0;
+            public T e1;
+            public T e2;
+            public T e3;
+#pragma warning restore CS0649
 
-            internal ref T this[int index]
+            public ref T this[int index]
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
@@ -1914,24 +1916,26 @@ namespace TerraFX.Interop
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref e0, (int)D3D12MA_HEAP_TYPE_COUNT);
+            public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref e0, (int)D3D12MA_HEAP_TYPE_COUNT);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal struct _D3D12MA_DEFAULT_POOL_MAX_COUNT_e__FixedBuffer<T>
+        private struct _D3D12MA_DEFAULT_POOL_MAX_COUNT_e__FixedBuffer<T>
             where T : unmanaged
         {
-            internal T e0;
-            internal T e1;
-            internal T e2;
-            internal T e3;
-            internal T e4;
-            internal T e5;
-            internal T e6;
-            internal T e7;
-            internal T e8;
+#pragma warning disable CS0649
+            public T e0;
+            public T e1;
+            public T e2;
+            public T e3;
+            public T e4;
+            public T e5;
+            public T e6;
+            public T e7;
+            public T e8;
+#pragma warning restore CS0649
 
-            internal ref T this[int index]
+            public ref T this[int index]
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
@@ -1941,7 +1945,7 @@ namespace TerraFX.Interop
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref e0, (int)D3D12MA_DEFAULT_POOL_MAX_COUNT);
+            public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref e0, (int)D3D12MA_DEFAULT_POOL_MAX_COUNT);
         }
     }
 }

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_BlockVector.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_BlockVector.cs
@@ -18,7 +18,7 @@ namespace TerraFX.Interop
     /// </summary>
     internal unsafe struct D3D12MA_BlockVector : IDisposable
     {
-        private D3D12MA_AllocatorPimpl* m_hAllocator;
+        private D3D12MA_Allocator* m_hAllocator;
 
         private D3D12_HEAP_PROPERTIES m_HeapProps;
 
@@ -51,7 +51,7 @@ namespace TerraFX.Interop
         [NativeTypeName("UINT")]
         private uint m_NextBlockId;
 
-        internal static void _ctor(ref D3D12MA_BlockVector pThis, D3D12MA_AllocatorPimpl* hAllocator, [NativeTypeName("const D3D12_HEAP_PROPERTIES&")] D3D12_HEAP_PROPERTIES* heapProps, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong preferredBlockSize, [NativeTypeName("size_t")] nuint minBlockCount, [NativeTypeName("size_t")] nuint maxBlockCount, bool explicitBlockSize)
+        internal static void _ctor(ref D3D12MA_BlockVector pThis, D3D12MA_Allocator* hAllocator, [NativeTypeName("const D3D12_HEAP_PROPERTIES&")] D3D12_HEAP_PROPERTIES* heapProps, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong preferredBlockSize, [NativeTypeName("size_t")] nuint minBlockCount, [NativeTypeName("size_t")] nuint maxBlockCount, bool explicitBlockSize)
         {
             pThis.m_hAllocator = hAllocator;
             pThis.m_HeapProps = *heapProps;

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_JsonWriter.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_JsonWriter.cs
@@ -29,6 +29,16 @@ namespace TerraFX.Interop
             m_InsideString = false;
         }
 
+        public D3D12MA_JsonWriter([NativeTypeName("const D3D12MA_ALLOCATION_CALLBACKS&")] ref D3D12MA_ALLOCATION_CALLBACKS allocationCallbacks, [NativeTypeName("StringBuilder&")] D3D12MA_StringBuilder* stringBuilder)
+        {
+            m_SB = stringBuilder;
+
+            Unsafe.SkipInit(out m_Stack);
+            D3D12MA_Vector<StackItem>._ctor(ref m_Stack, (D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref allocationCallbacks));
+
+            m_InsideString = false;
+        }
+
         public void Dispose()
         {
             D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && !m_InsideString);

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_MemoryBlock.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_MemoryBlock.cs
@@ -25,7 +25,7 @@ namespace TerraFX.Interop
 
         internal void** lpVtbl;
 
-        internal readonly D3D12MA_AllocatorPimpl* m_Allocator;
+        internal readonly D3D12MA_Allocator* m_Allocator;
 
         internal readonly D3D12_HEAP_PROPERTIES m_HeapProps;
 
@@ -38,7 +38,7 @@ namespace TerraFX.Interop
 
         internal ID3D12Heap* m_Heap;
 
-        public D3D12MA_MemoryBlock(D3D12MA_AllocatorPimpl* allocator, [NativeTypeName("const D3D12_HEAP_PROPERTIES&")] D3D12_HEAP_PROPERTIES* heapProps, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong size, [NativeTypeName("UINT")] uint id)
+        public D3D12MA_MemoryBlock(D3D12MA_Allocator* allocator, [NativeTypeName("const D3D12_HEAP_PROPERTIES&")] D3D12_HEAP_PROPERTIES* heapProps, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong size, [NativeTypeName("UINT")] uint id)
         {
             lpVtbl = Vtbl;
 

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_NormalBlock.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_NormalBlock.cs
@@ -28,7 +28,7 @@ namespace TerraFX.Interop
 
         private D3D12MA_BlockVector* m_BlockVector;
 
-        public static void _ctor(ref D3D12MA_NormalBlock pThis, D3D12MA_AllocatorPimpl* allocator, ref D3D12MA_BlockVector blockVector, [NativeTypeName("const D3D12_HEAP_PROPERTIES&")] D3D12_HEAP_PROPERTIES* heapProps, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong size, [NativeTypeName("UINT")] uint id)
+        public static void _ctor(ref D3D12MA_NormalBlock pThis, D3D12MA_Allocator* allocator, ref D3D12MA_BlockVector blockVector, [NativeTypeName("const D3D12_HEAP_PROPERTIES&")] D3D12_HEAP_PROPERTIES* heapProps, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong size, [NativeTypeName("UINT")] uint id)
         {
             pThis.Base = new D3D12MA_MemoryBlock(allocator, heapProps, heapFlags, size, id);
             pThis.Base.lpVtbl = Vtbl;

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
@@ -9,7 +9,7 @@ using static TerraFX.Interop.D3D12MemAlloc;
 
 namespace TerraFX.Interop
 {
-    public unsafe partial struct D3D12MA_Pool : IDisposable, D3D12MA_IItemTypeTraits<D3D12MA_Pool>
+    public unsafe partial struct D3D12MA_Pool : D3D12MA_IItemTypeTraits<D3D12MA_Pool>
     {
         internal D3D12MA_Allocator* m_Allocator; // Externally owned object
 
@@ -24,9 +24,9 @@ namespace TerraFX.Interop
 
         internal D3D12MA_Pool* m_NextPool;
 
-        internal static void _ctor(ref D3D12MA_Pool pThis, D3D12MA_Allocator* allocator, [NativeTypeName("const D3D12MA_POOL_DESC&")] D3D12MA_POOL_DESC* desc)
+        internal static void _ctor(ref D3D12MA_Pool pThis, ref D3D12MA_Allocator allocator, [NativeTypeName("const D3D12MA_POOL_DESC&")] D3D12MA_POOL_DESC* desc)
         {
-            pThis.m_Allocator = allocator;
+            pThis.m_Allocator = (D3D12MA_Allocator*)Unsafe.AsPointer(ref allocator);
             pThis.m_Desc = *desc;
             pThis.m_BlockVector = null;
             pThis.m_Name = null;
@@ -39,10 +39,12 @@ namespace TerraFX.Interop
             D3D12_HEAP_FLAGS heapFlags = desc->HeapFlags;
             uint maxBlockCount = desc->MaxBlockCount != 0 ? desc->MaxBlockCount : uint.MaxValue;
 
-            pThis.m_BlockVector = D3D12MA_NEW<D3D12MA_BlockVector>(allocator->GetAllocs());
+            pThis.m_BlockVector = D3D12MA_NEW<D3D12MA_BlockVector>(allocator.GetAllocs());
             D3D12MA_BlockVector._ctor(
                 ref *pThis.m_BlockVector,
-                allocator, &desc->HeapProperties, heapFlags,
+                (D3D12MA_Allocator*)Unsafe.AsPointer(ref allocator),
+                &desc->HeapProperties,
+                heapFlags,
                 preferredBlockSize,
                 desc->MinBlockCount, maxBlockCount,
                 explicitBlockSize

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
@@ -9,22 +9,22 @@ using static TerraFX.Interop.D3D12MemAlloc;
 
 namespace TerraFX.Interop
 {
-    internal unsafe struct D3D12MA_PoolPimpl : IDisposable, D3D12MA_IItemTypeTraits<D3D12MA_PoolPimpl>
+    public unsafe partial struct D3D12MA_Pool : IDisposable, D3D12MA_IItemTypeTraits<D3D12MA_Pool>
     {
-        public D3D12MA_Allocator* m_Allocator; // Externally owned object
+        internal D3D12MA_Allocator* m_Allocator; // Externally owned object
 
-        public D3D12MA_POOL_DESC m_Desc;
+        internal D3D12MA_POOL_DESC m_Desc;
 
-        public D3D12MA_BlockVector* m_BlockVector; // Owned object
+        internal D3D12MA_BlockVector* m_BlockVector; // Owned object
 
         [NativeTypeName("wchar_t*")]
-        public ushort* m_Name;
+        internal ushort* m_Name;
 
-        public D3D12MA_PoolPimpl* m_PrevPool;
+        internal D3D12MA_Pool* m_PrevPool;
 
-        public D3D12MA_PoolPimpl* m_NextPool;
+        internal D3D12MA_Pool* m_NextPool;
 
-        internal static void _ctor(ref D3D12MA_PoolPimpl pThis, D3D12MA_Allocator* allocator, [NativeTypeName("const D3D12MA_POOL_DESC&")] D3D12MA_POOL_DESC* desc)
+        internal static void _ctor(ref D3D12MA_Pool pThis, D3D12MA_Allocator* allocator, [NativeTypeName("const D3D12MA_POOL_DESC&")] D3D12MA_POOL_DESC* desc)
         {
             pThis.m_Allocator = allocator;
             pThis.m_Desc = *desc;
@@ -50,28 +50,31 @@ namespace TerraFX.Interop
         }
 
         [return: NativeTypeName("HRESULT")]
-        public int Init()
+        internal int Init()
         {
             return m_BlockVector->CreateMinBlocks();
         }
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
+            GetAllocator()->UnregisterPool(ref this, m_Desc.HeapProperties.Type);
+
             D3D12MA_ASSERT((D3D12MA_DEBUG_LEVEL > 0) && (m_PrevPool == null) && (m_NextPool == null));
             FreeName();
             D3D12MA_DELETE(m_Allocator->GetAllocs(), m_BlockVector);
         }
 
-        public readonly D3D12MA_Allocator* GetAllocator() => m_Allocator;
+        internal readonly D3D12MA_Allocator* GetAllocator() => m_Allocator;
 
-        public readonly D3D12MA_POOL_DESC* GetDesc() => (D3D12MA_POOL_DESC*)Unsafe.AsPointer(ref Unsafe.AsRef(m_Desc));
-
-        public D3D12MA_BlockVector* GetBlockVector() => m_BlockVector;
+        internal D3D12MA_BlockVector* GetBlockVector() => m_BlockVector;
 
         [return: NativeTypeName("HRESULT")]
-        public int SetMinBytes([NativeTypeName("UINT64")] ulong minBytes) => m_BlockVector->SetMinBytes(minBytes);
+        private int SetMinBytesPimpl([NativeTypeName("UINT64")] ulong minBytes)
+        {
+            return m_BlockVector->SetMinBytes(minBytes);
+        }
 
-        public void CalculateStats([NativeTypeName("StatInfo&")] D3D12MA_StatInfo* outStats)
+        private void CalculateStatsPimpl([NativeTypeName("StatInfo&")] D3D12MA_StatInfo* outStats)
         {
             ZeroMemory(outStats, (nuint)sizeof(D3D12MA_StatInfo));
 
@@ -82,7 +85,7 @@ namespace TerraFX.Interop
             PostProcessStatInfo(ref *outStats);
         }
 
-        public void SetName([NativeTypeName("LPCWSTR")] ushort* Name)
+        private void SetNamePimpl([NativeTypeName("LPCWSTR")] ushort* Name)
         {
             FreeName();
 
@@ -94,9 +97,6 @@ namespace TerraFX.Interop
             }
         }
 
-        [return: NativeTypeName("LPCWSTR")]
-        public readonly ushort* GetName() => m_Name;
-
         private void FreeName()
         {
             if (m_Name != null)
@@ -107,18 +107,18 @@ namespace TerraFX.Interop
             }
         }
 
-        public readonly D3D12MA_PoolPimpl* GetPrev() => m_PrevPool;
+        readonly D3D12MA_Pool* D3D12MA_IItemTypeTraits<D3D12MA_Pool>.GetPrev() => m_PrevPool;
 
-        public readonly D3D12MA_PoolPimpl* GetNext() => m_NextPool;
+        readonly D3D12MA_Pool* D3D12MA_IItemTypeTraits<D3D12MA_Pool>.GetNext() => m_NextPool;
 
-        public readonly D3D12MA_PoolPimpl** AccessPrev()
+        readonly D3D12MA_Pool** D3D12MA_IItemTypeTraits<D3D12MA_Pool>.AccessPrev()
         {
-            return &((D3D12MA_PoolPimpl*)Unsafe.AsPointer(ref Unsafe.AsRef(in this)))->m_PrevPool;
+            return &((D3D12MA_Pool*)Unsafe.AsPointer(ref Unsafe.AsRef(in this)))->m_PrevPool;
         }
 
-        public readonly D3D12MA_PoolPimpl** AccessNext()
+        readonly D3D12MA_Pool** D3D12MA_IItemTypeTraits<D3D12MA_Pool>.AccessNext()
         {
-            return &((D3D12MA_PoolPimpl*)Unsafe.AsPointer(ref Unsafe.AsRef(in this)))->m_NextPool;
+            return &((D3D12MA_Pool*)Unsafe.AsPointer(ref Unsafe.AsRef(in this)))->m_NextPool;
         }
     }
 }

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_PoolPimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_PoolPimpl.cs
@@ -11,7 +11,7 @@ namespace TerraFX.Interop
 {
     internal unsafe struct D3D12MA_PoolPimpl : IDisposable, D3D12MA_IItemTypeTraits<D3D12MA_PoolPimpl>
     {
-        public D3D12MA_AllocatorPimpl* m_Allocator; // Externally owned object
+        public D3D12MA_Allocator* m_Allocator; // Externally owned object
 
         public D3D12MA_POOL_DESC m_Desc;
 
@@ -24,7 +24,7 @@ namespace TerraFX.Interop
 
         public D3D12MA_PoolPimpl* m_NextPool;
 
-        internal static void _ctor(ref D3D12MA_PoolPimpl pThis, D3D12MA_AllocatorPimpl* allocator, [NativeTypeName("const D3D12MA_POOL_DESC&")] D3D12MA_POOL_DESC* desc)
+        internal static void _ctor(ref D3D12MA_PoolPimpl pThis, D3D12MA_Allocator* allocator, [NativeTypeName("const D3D12MA_POOL_DESC&")] D3D12MA_POOL_DESC* desc)
         {
             pThis.m_Allocator = allocator;
             pThis.m_Desc = *desc;
@@ -62,7 +62,7 @@ namespace TerraFX.Interop
             D3D12MA_DELETE(m_Allocator->GetAllocs(), m_BlockVector);
         }
 
-        public readonly D3D12MA_AllocatorPimpl* GetAllocator() => m_Allocator;
+        public readonly D3D12MA_Allocator* GetAllocator() => m_Allocator;
 
         public readonly D3D12MA_POOL_DESC* GetDesc() => (D3D12MA_POOL_DESC*)Unsafe.AsPointer(ref Unsafe.AsRef(m_Desc));
 

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_StringBuilder.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_StringBuilder.cs
@@ -20,6 +20,12 @@ namespace TerraFX.Interop
             D3D12MA_Vector<ushort>._ctor(ref m_Data, allocationCallbacks);
         }
 
+        public D3D12MA_StringBuilder(ref D3D12MA_ALLOCATION_CALLBACKS allocationCallbacks)
+        {
+            Unsafe.SkipInit(out m_Data);
+            D3D12MA_Vector<ushort>._ctor(ref m_Data, (D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref allocationCallbacks));
+        }
+
         public void Dispose() => m_Data.Dispose();
 
         [return: NativeTypeName("size_t")]

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_VirtualBlock.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_VirtualBlock.Pimpl.cs
@@ -3,21 +3,20 @@
 // Ported from D3D12MemAlloc.cpp in D3D12MemoryAllocator commit 5457bcdaee73ee1f3fe6027bbabf959119f88b3d
 // Original source is Copyright © Advanced Micro Devices, Inc. All rights reserved. Licensed under the MIT License (MIT).
 
-using System;
 using System.Runtime.CompilerServices;
 
 namespace TerraFX.Interop
 {
-    internal unsafe struct D3D12MA_VirtualBlockPimpl : IDisposable
+    public unsafe partial struct D3D12MA_VirtualBlock
     {
-        public D3D12MA_ALLOCATION_CALLBACKS m_AllocationCallbacks;
+        internal D3D12MA_ALLOCATION_CALLBACKS m_AllocationCallbacks;
 
         [NativeTypeName("UINT64")]
-        public ulong m_Size;
+        internal ulong m_Size;
 
-        public D3D12MA_BlockMetadata_Generic m_Metadata;
+        internal D3D12MA_BlockMetadata_Generic m_Metadata;
 
-        public static void _ctor(ref D3D12MA_VirtualBlockPimpl pThis, D3D12MA_ALLOCATION_CALLBACKS* allocationCallbacks, [NativeTypeName("UINT64")] ulong size)
+        internal static void _ctor(ref D3D12MA_VirtualBlock pThis, D3D12MA_ALLOCATION_CALLBACKS* allocationCallbacks, [NativeTypeName("UINT64")] ulong size)
         {
             pThis.m_AllocationCallbacks = *allocationCallbacks;
             pThis.m_Size = size;
@@ -25,11 +24,6 @@ namespace TerraFX.Interop
             D3D12MA_BlockMetadata_Generic._ctor(ref pThis.m_Metadata, (D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref pThis.m_AllocationCallbacks), true); // isVirtual
 
             pThis.m_Metadata.Init(pThis.m_Size);
-        }
-
-        public void Dispose()
-        {
-            m_Metadata.Dispose();
         }
     }
 }

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
@@ -72,6 +72,11 @@ namespace TerraFX.Interop
             allocs->pFree(memory, allocs->pUserData);
         }
 
+        internal static void Free([NativeTypeName("const ALLOCATION_CALLBACKS&")] ref D3D12MA_ALLOCATION_CALLBACKS allocs, void* memory)
+        {
+            allocs.pFree(memory, allocs.pUserData);
+        }
+
         internal static T* Allocate<T>([NativeTypeName("const ALLOCATION_CALLBACKS&")] D3D12MA_ALLOCATION_CALLBACKS* allocs)
             where T : unmanaged
         {
@@ -82,6 +87,12 @@ namespace TerraFX.Interop
             where T : unmanaged
         {
             return (T*)Malloc(allocs, (nuint)sizeof(T) * count, __alignof<T>());
+        }
+
+        internal static T* AllocateArray<T>([NativeTypeName("const ALLOCATION_CALLBACKS&")] ref D3D12MA_ALLOCATION_CALLBACKS allocs, [NativeTypeName("size_t")] nuint count)
+            where T : unmanaged
+        {
+            return (T*)Malloc((D3D12MA_ALLOCATION_CALLBACKS*)Unsafe.AsPointer(ref allocs), (nuint)sizeof(T) * count, __alignof<T>());
         }
 
         internal static T* D3D12MA_NEW<T>([NativeTypeName("const ALLOCATION_CALLBACKS&")] D3D12MA_ALLOCATION_CALLBACKS* allocs)

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
@@ -815,7 +815,7 @@ namespace TerraFX.Interop
             D3D12MA_Allocator._ctor(ref *allocator, &allocationCallbacks, pDesc);
             *ppAllocator = allocator;
 
-            HRESULT hr = (*ppAllocator)->m_Pimpl->Init(pDesc);
+            HRESULT hr = (*ppAllocator)->Init(pDesc);
 
             if (FAILED(hr))
             {


### PR DESCRIPTION
- Renamed D3D12MA_AllocatorPimpl.cs to D3D12MA_Allocator.Pimpl.cs (partial type)
- Deleted D3D12MA_AllocatorPimpl* m_Pimpl field from D3D12MA_Allocator (now inline)
- Inlined GetD3D12Options, IsUMA, IsCacheCoherentUMA
- Deleted _ctor and Dispose methods from D3D12MA_Allocator (now unnecessary)
- Adjusted methods visibility from public to private/internal where needed
- Applied the same transformations to D3D12MA_PoolPimpl and D3D12MA_VirtualBlockPimpl