### PR TITLE
Committed allocations with custom pools

### DIFF
--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocation.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocation.cs
@@ -251,7 +251,7 @@ namespace TerraFX.Interop
 
             public struct _m_Committed_e__Struct
             {
-                public D3D12_HEAP_TYPE heapType;
+                public D3D12MA_CommittedAllocationList* list;
                 public D3D12MA_Allocation* prev;
                 public D3D12MA_Allocation* next;
             }
@@ -266,7 +266,7 @@ namespace TerraFX.Interop
 
             public struct _m_Heap_e__Struct
             {
-                public D3D12_HEAP_TYPE heapType;
+                public D3D12MA_CommittedAllocationList* list;
                 public D3D12MA_Allocation* prev;
                 public D3D12MA_Allocation* next;
                 public ID3D12Heap* heap;
@@ -377,10 +377,15 @@ namespace TerraFX.Interop
             // Nothing here, everything already done in Release.
         }
 
-        internal void InitCommitted(D3D12_HEAP_TYPE heapType)
+        internal void InitCommitted(ref D3D12MA_CommittedAllocationList list)
+        {
+            InitCommitted((D3D12MA_CommittedAllocationList*)Unsafe.AsPointer(ref list));
+        }
+
+        internal void InitCommitted(D3D12MA_CommittedAllocationList* list)
         {
             m_PackedData.SetType(TYPE_COMMITTED);
-            m_Committed.heapType = heapType;
+            m_Committed.list = list;
             m_Committed.prev = null;
             m_Committed.next = null;
         }
@@ -392,10 +397,15 @@ namespace TerraFX.Interop
             m_Placed.block = block;
         }
 
-        internal void InitHeap(D3D12_HEAP_TYPE heapType, ID3D12Heap* heap)
+        internal void InitHeap(ref D3D12MA_CommittedAllocationList list, ID3D12Heap* heap)
+        {
+            InitHeap((D3D12MA_CommittedAllocationList*)Unsafe.AsPointer(ref list), heap);
+        }
+
+        internal void InitHeap(D3D12MA_CommittedAllocationList* list, ID3D12Heap* heap)
         {
             m_PackedData.SetType(TYPE_HEAP);
-            m_Heap.heapType = heapType;
+            m_Heap.list = list;
             m_Heap.heap = heap;
             m_Committed.prev = null;
             m_Committed.next = null;

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Allocator.cs
@@ -9,7 +9,6 @@ using static TerraFX.Interop.D3D12MemAlloc;
 using static TerraFX.Interop.Windows;
 using static TerraFX.Interop.D3D12_HEAP_FLAGS;
 using static TerraFX.Interop.D3D12MA_ALLOCATION_FLAGS;
-using static TerraFX.Interop.D3D12_HEAP_TYPE;
 
 namespace TerraFX.Interop
 {
@@ -289,21 +288,6 @@ namespace TerraFX.Interop
             }
 
             return hr;
-        }
-
-        /// <summary>Sets the minimum number of bytes that should always be allocated (reserved) in a specific default pool.</summary>
-        /// <param name="heapType">Must be one of: <see cref="D3D12_HEAP_TYPE_DEFAULT"/>, <see cref="D3D12_HEAP_TYPE_UPLOAD"/>, <see cref="D3D12_HEAP_TYPE_READBACK"/>.</param>
-        /// <param name="heapFlags">
-        /// Must be one of: <see cref="D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS"/>, <see cref="D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES"/>,
-        /// <see cref="D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES"/>. If <c>ResourceHeapTier = 2</c>, it can also be <see cref="D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES"/>.
-        /// </param>
-        /// <param name="minBytes">Minimum number of bytes to keep allocated.</param>
-        /// <remarks>See also: reserving_memory.</remarks>
-        [return: NativeTypeName("HRESULT")]
-        public int SetDefaultHeapMinBytes(D3D12_HEAP_TYPE heapType, D3D12_HEAP_FLAGS heapFlags, [NativeTypeName("UINT64")] ulong minBytes)
-        {
-            using var debugGlobalMutexLock = D3D12MA_DEBUG_GLOBAL_MUTEX_LOCK();
-            return SetDefaultHeapMinBytesPimpl(heapType, heapFlags, minBytes);
         }
 
         /// <summary>

--- a/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
+++ b/sources/Interop/D3D12MemoryAllocator/inc/D3D12MemAlloc/D3D12MA_Pool.cs
@@ -33,16 +33,6 @@ namespace TerraFX.Interop
         /// </summary>
         public readonly D3D12MA_POOL_DESC GetDesc() => m_Desc;
 
-        /// <summary>
-        /// Sets the minimum number of bytes that should always be allocated (reserved) in this pool.
-        /// <para>See also: reserving_memory.</para>
-        /// </summary>
-        [return: NativeTypeName("HRESULT")]
-        public int SetMinBytes([NativeTypeName("UINT64")] ulong minBytes)
-        {
-            return SetMinBytesPimpl(minBytes);
-        }
-
         /// <summary>Retrieves statistics from the current state of this pool.</summary>
         public void CalculateStats(D3D12MA_StatInfo* pStats)
         {

--- a/sources/Interop/D3D12MemoryAllocator/inc/docs.md
+++ b/sources/Interop/D3D12MemoryAllocator/inc/docs.md
@@ -227,7 +227,7 @@ Pool* pool;
 HRESULT hr = allocator->CreatePool(&poolDesc, &pool);
 ```
 
-To allocate resources out of a custom pool, only set member `D3D12MA::ALLOCATION_DESC::CustomPool`. Other members of this structure are then ignored. Example:
+To allocate resources out of a custom pool, only set member `D3D12MA::ALLOCATION_DESC::CustomPool`. Example:
 
 ```cpp
 ALLOCATION_DESC allocDesc = {};
@@ -238,9 +238,8 @@ hr = allocator->CreateResource(&allocDesc, &resDesc,
     D3D12_RESOURCE_STATE_GENERIC_READ, NULL, &alloc, IID_NULL, NULL);
 ```
 
-Currently all allocations from custom pools are created as Placed, never as Committed.
 All allocations must be released before releasing the pool.
-The pool must be released before relasing the allocator.
+The pool must be released before releasing the allocator.
 
 ```cpp
 alloc->Release();
@@ -251,11 +250,34 @@ pool->Release();
 
 While it is recommended to use default pools whenever possible for simplicity and to give the allocator more opportunities for internal optimizations, custom pools may be useful in following cases:
 - To keep some resources separate from others in memory.
+' To keep track of memory usage of just a specific group of resources. Statistics can be queried using `D3D12MA::Pool::CalculateStats`.
 - To use specific size of a memory block (`ID3D12Heap`). To set it, use member `D3D12MA::POOL_DESC::BlockSize`.
-  When set to 0, the library uses automatically determined, increasing block sizes.
+  When set to 0, the library uses automatically determined, variable block sizes.
 - To reserve some minimum amount of memory allocated. To use it, set member `D3D12MA::POOL_DESC::MinBlockCount`.
 - To limit maximum amount of memory allocated. To use it, set member `D3D12MA::POOL_DESC::MaxBlockCount`.
 - To use extended parameters of the D3D12 memory allocation. While resources created from default pools can only specify `D3D12_HEAP_TYPE_DEFAULT`, `UPLOAD`, `READBACK`, a custom pool may use non-standard `D3D12_HEAP_PROPERTIES` (member D3D12MA::POOL_DESC::HeapProperties) and `D3D12_HEAP_FLAGS` (`D3D12MA::POOL_DESC::HeapFlags`), which is useful e.g. for cross-adapter sharing or UMA (see also `D3D12MA::Allocator::IsUMA`).
+
+New versions of this library support creating **committed allocations in custom pools**.
+
+It is supported only when `D3D12MA::POOL_DESC::BlockSize = 0`.
+To use this feature, set `D3D12MA::ALLOCATION_DESC::CustomPool` to the pointer to your custom pool and
+`D3D12MA::ALLOCATION_DESC::Flags` to `D3D12MA::ALLOCATION_FLAG_COMMITTED`. Example:
+
+```cpp
+ALLOCATION_DESC allocDesc = {};
+allocDesc.CustomPool = pool;
+allocDesc.Flags = ALLOCATION_FLAG_COMMITTED;
+
+D3D12_RESOURCE_DESC resDesc = ...
+Allocation* alloc;
+ID3D12Resource* res;
+hr = allocator->CreateResource(&allocDesc, &resDesc,
+    D3D12_RESOURCE_STATE_GENERIC_READ, NULL, &alloc, IID_PPV_ARGS(&res));
+```
+
+This feature may seem unnecessary, but creating committed allocations from custom pools may be useful
+in some cases, e.g. to have separate memory usage statistics for some group of resources or to use
+extended allocation parameters, like custom `D3D12_HEAP_PROPERTIES`, which are available only in custom pools.
 
 ## Resource aliasing
 

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
@@ -285,7 +285,7 @@ namespace TerraFX.Interop
             int hr = CalcAllocationParams(
                 pAllocDesc,
                 resAllocInfo.SizeInBytes,
-                null, // pResDesc
+                pResourceDesc,
                 out blockVector,
                 out committedAllocationParams,
                 out preferCommitted);
@@ -391,7 +391,7 @@ namespace TerraFX.Interop
             int hr = CalcAllocationParams(
                 pAllocDesc,
                 resAllocInfo.SizeInBytes,
-                null, // pResDesc
+                pResourceDesc,
                 out blockVector,
                 out committedAllocationParams,
                 out preferCommitted);
@@ -455,7 +455,7 @@ namespace TerraFX.Interop
             int hr = CalcAllocationParams(
                 pAllocDesc,
                 resAllocInfo.SizeInBytes,
-                null, // pResDesc
+                (D3D12_RESOURCE_DESC*)pResourceDesc,
                 out blockVector,
                 out committedAllocationParams,
                 out preferCommitted);

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
@@ -681,10 +681,7 @@ namespace TerraFX.Interop
 
             ulong allocationSize = allocation->GetSize();
             uint heapTypeIndex = HeapTypeToIndex(allocList->GetHeapType());
-            m_Budget.RemoveAllocation(heapTypeIndex, allocationSize);
-
-            ref ulong blockBytes = ref m_Budget.m_BlockBytes[(int)heapTypeIndex];
-            Volatile.Write(ref blockBytes, Volatile.Read(ref blockBytes) - allocationSize);
+            m_Budget.RemoveCommittedAllocation(heapTypeIndex, allocationSize);
         }
 
         /// <summary>
@@ -730,11 +727,7 @@ namespace TerraFX.Interop
 
             uint heapTypeIndex = HeapTypeToIndex(allocList->GetHeapType());
             ulong allocationSize = allocation->GetSize();
-
-            ref ulong blockBytes = ref m_Budget.m_BlockBytes[(int)heapTypeIndex];
-            Volatile.Write(ref blockBytes, Volatile.Read(ref blockBytes) - allocationSize);
-
-            m_Budget.RemoveAllocation(heapTypeIndex, allocationSize);
+            m_Budget.RemoveCommittedAllocation(heapTypeIndex, allocationSize);
         }
 
         private void SetCurrentFrameIndexPimpl([NativeTypeName("UINT")] uint frameIndex)
@@ -1087,10 +1080,7 @@ namespace TerraFX.Interop
                     committedAllocParams->m_List->Register(alloc);
 
                     uint heapTypeIndex = HeapTypeToIndex(committedAllocParams->m_HeapProperties.Type);
-                    m_Budget.AddAllocation(heapTypeIndex, resourceSize);
-
-                    ref ulong blockBytes = ref m_Budget.m_BlockBytes[(int)heapTypeIndex];
-                    Volatile.Write(ref blockBytes, Volatile.Read(ref blockBytes) + resourceSize);
+                    m_Budget.AddCommittedAllocation(heapTypeIndex, resourceSize);
                 }
                 else
                 {
@@ -1147,10 +1137,7 @@ namespace TerraFX.Interop
                     committedAllocParams->m_List->Register(alloc);
 
                     uint heapTypeIndex = HeapTypeToIndex(committedAllocParams->m_HeapProperties.Type);
-                    m_Budget.AddAllocation(heapTypeIndex, resourceSize);
-
-                    ref ulong blockBytes = ref m_Budget.m_BlockBytes[(int)heapTypeIndex];
-                    Volatile.Write(ref blockBytes, Volatile.Read(ref blockBytes) + resourceSize);
+                    m_Budget.AddCommittedAllocation(heapTypeIndex, resourceSize);
                 }
                 else
                 {
@@ -1208,10 +1195,7 @@ namespace TerraFX.Interop
                     committedAllocParams->m_List->Register(alloc);
 
                     uint heapTypeIndex = HeapTypeToIndex(committedAllocParams->m_HeapProperties.Type);
-                    m_Budget.AddAllocation(heapTypeIndex, resourceSize);
-
-                    ref ulong blockBytes = ref m_Budget.m_BlockBytes[(int)heapTypeIndex];
-                    Volatile.Write(ref blockBytes, Volatile.Read(ref blockBytes) + resourceSize);
+                    m_Budget.AddCommittedAllocation(heapTypeIndex, resourceSize);
                 }
                 else
                 {
@@ -1253,10 +1237,7 @@ namespace TerraFX.Interop
                 committedAllocParams->m_List->Register(*ppAllocation);
 
                 uint heapTypeIndex = HeapTypeToIndex(committedAllocParams->m_HeapProperties.Type);
-                m_Budget.AddAllocation(heapTypeIndex, allocInfo->SizeInBytes);
-
-                ref ulong blockBytes = ref m_Budget.m_BlockBytes[(int)heapTypeIndex];
-                Volatile.Write(ref blockBytes, Volatile.Read(ref blockBytes) + allocInfo->SizeInBytes);
+                m_Budget.AddCommittedAllocation(heapTypeIndex, allocInfo->SizeInBytes);
             }
 
             return hr;
@@ -1296,9 +1277,7 @@ namespace TerraFX.Interop
                 committedAllocParams->m_List->Register(*ppAllocation);
 
                 uint heapTypeIndex = HeapTypeToIndex(committedAllocParams->m_HeapProperties.Type);
-                m_Budget.AddAllocation(heapTypeIndex, allocInfo->SizeInBytes);
-                ref ulong blockBytes = ref m_Budget.m_BlockBytes[(int)heapTypeIndex];
-                Volatile.Write(ref blockBytes, Volatile.Read(ref blockBytes) + allocInfo->SizeInBytes);
+                m_Budget.AddCommittedAllocation(heapTypeIndex, allocInfo->SizeInBytes);
             }
 
             return hr;

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
@@ -1054,7 +1054,7 @@ namespace TerraFX.Interop
             ID3D12Resource* res = null;
             HRESULT hr = m_Device->CreateCommittedResource(
                 &committedAllocParams->m_HeapProperties,
-                committedAllocParams->m_HeapFlags,
+                committedAllocParams->m_HeapFlags & ~RESOURCE_CLASS_HEAP_FLAGS, // D3D12 ERROR: ID3D12Device::CreateCommittedResource: When creating a committed resource, D3D12_HEAP_FLAGS must not have either D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES, D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES, nor D3D12_HEAP_FLAG_DENY_BUFFERS set. These flags will be set automatically to correspond with the committed resource type. [ STATE_CREATION ERROR #640: CREATERESOURCEANDHEAP_INVALIDHEAPMISCFLAGS]
                 pResourceDesc,
                 InitialResourceState,
                 pOptimizedClearValue,
@@ -1110,7 +1110,7 @@ namespace TerraFX.Interop
             ID3D12Resource* res = null;
             HRESULT hr = m_Device4->CreateCommittedResource1(
                 &committedAllocParams->m_HeapProperties,
-                committedAllocParams->m_HeapFlags,
+                committedAllocParams->m_HeapFlags & ~RESOURCE_CLASS_HEAP_FLAGS, // D3D12 ERROR: ID3D12Device::CreateCommittedResource: When creating a committed resource, D3D12_HEAP_FLAGS must not have either D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES, D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES, nor D3D12_HEAP_FLAG_DENY_BUFFERS set. These flags will be set automatically to correspond with the committed resource type. [ STATE_CREATION ERROR #640: CREATERESOURCEANDHEAP_INVALIDHEAPMISCFLAGS]
                 pResourceDesc,
                 InitialResourceState,
                 pOptimizedClearValue,
@@ -1167,7 +1167,7 @@ namespace TerraFX.Interop
             ID3D12Resource* res = null;
             HRESULT hr = m_Device8->CreateCommittedResource2(
                 &committedAllocParams->m_HeapProperties,
-                committedAllocParams->m_HeapFlags,
+                committedAllocParams->m_HeapFlags & ~RESOURCE_CLASS_HEAP_FLAGS, // D3D12 ERROR: ID3D12Device::CreateCommittedResource: When creating a committed resource, D3D12_HEAP_FLAGS must not have either D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES, D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES, nor D3D12_HEAP_FLAG_DENY_BUFFERS set. These flags will be set automatically to correspond with the committed resource type. [ STATE_CREATION ERROR #640: CREATERESOURCEANDHEAP_INVALIDHEAPMISCFLAGS]
                 pResourceDesc,
                 InitialResourceState,
                 pOptimizedClearValue,
@@ -1298,7 +1298,7 @@ namespace TerraFX.Interop
 
                 outCommittedAllocationParams.m_HeapProperties = pool->GetDesc().HeapProperties;
                 outCommittedAllocationParams.m_HeapFlags = pool->GetDesc().HeapFlags;
-                //outCommittedAllocationParams.m_List = pool->GetCommittedAllocationList(); // TODO
+                outCommittedAllocationParams.m_List = pool->GetCommittedAllocationList();
             }
             else
             {

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
@@ -1015,9 +1015,7 @@ namespace TerraFX.Interop
                 return E_OUTOFMEMORY;
             }
 
-            D3D12_HEAP_PROPERTIES heapProps = default;
-            heapProps.Type = pAllocDesc->HeapType;
-
+            D3D12_HEAP_PROPERTIES heapProps = StandardHeapTypeToHeapProperties(pAllocDesc->HeapType);
             D3D12_HEAP_FLAGS heapFlags = pAllocDesc->ExtraHeapFlags;
 
             ID3D12Resource* res = null;
@@ -1077,9 +1075,7 @@ namespace TerraFX.Interop
                 return E_OUTOFMEMORY;
             }
 
-            D3D12_HEAP_PROPERTIES heapProps = default;
-            heapProps.Type = pAllocDesc->HeapType;
-
+            D3D12_HEAP_PROPERTIES heapProps = StandardHeapTypeToHeapProperties(pAllocDesc->HeapType);
             D3D12_HEAP_FLAGS heapFlags = pAllocDesc->ExtraHeapFlags;
 
             ID3D12Resource* res = null;
@@ -1139,9 +1135,7 @@ namespace TerraFX.Interop
                 return E_OUTOFMEMORY;
             }
 
-            D3D12_HEAP_PROPERTIES heapProps = default;
-            heapProps.Type = pAllocDesc->HeapType;
-
+            D3D12_HEAP_PROPERTIES heapProps = StandardHeapTypeToHeapProperties(pAllocDesc->HeapType);
             D3D12_HEAP_FLAGS heapFlags = pAllocDesc->ExtraHeapFlags;
 
             ID3D12Resource* res = null;
@@ -1203,8 +1197,8 @@ namespace TerraFX.Interop
 
             uint heapTypeIndex = HeapTypeToIndex(pAllocDesc->HeapType);
             ref D3D12MA_CommittedAllocationList allocList = ref m_CommittedAllocations[(int)heapTypeIndex];
-            D3D12_HEAP_PROPERTIES heapProps = default;
-            heapProps.Type = pAllocDesc->HeapType;
+
+            D3D12_HEAP_PROPERTIES heapProps = StandardHeapTypeToHeapProperties(pAllocDesc->HeapType);
             return AllocateHeap_Impl(ref allocList, heapProps, pAllocDesc->ExtraHeapFlags, allocInfo, ppAllocation);
         }
 
@@ -1259,8 +1253,8 @@ namespace TerraFX.Interop
 
             uint heapTypeIndex = HeapTypeToIndex(pAllocDesc->HeapType);
             ref D3D12MA_CommittedAllocationList allocList = ref m_CommittedAllocations[(int)heapTypeIndex];
-            D3D12_HEAP_PROPERTIES heapProps = default;
-            heapProps.Type = pAllocDesc->HeapType;
+
+            D3D12_HEAP_PROPERTIES heapProps = StandardHeapTypeToHeapProperties(pAllocDesc->HeapType);
             return AllocateHeap1_Impl(ref allocList, &heapProps, pAllocDesc->ExtraHeapFlags, allocInfo, pProtectedSession, ppAllocation);
         }
 
@@ -1302,8 +1296,7 @@ namespace TerraFX.Interop
             {
                 D3D12MA_Pool* pool = allocDesc->CustomPool;
                 outBlockVector = pool->GetBlockVector();
-                // TODO!
-                //outCommittedAllocationList = &pool->m_CommittedAllocations;
+                //outCommittedAllocationList = pool->GetCommittedAllocationList(); // TODO
             }
             else
             {
@@ -1355,7 +1348,7 @@ namespace TerraFX.Interop
                 outPreferCommitted = true;
             }
 
-            return S_OK;
+            return ((outBlockVector != null) || (outCommittedAllocationList != null)) ? S_OK : E_INVALIDARG;
         }
 
         /// <summary>

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
@@ -1315,7 +1315,7 @@ namespace TerraFX.Interop
                 uint defaultPoolIndex = CalcDefaultPoolIndex(allocDesc, resourceClass);
                 if (defaultPoolIndex != Windows.UINT32_MAX)
                 {
-                    outBlockVector = (D3D12MA_BlockVector*)Unsafe.AsPointer(ref m_BlockVectors[(int)defaultPoolIndex]);
+                    outBlockVector = m_BlockVectors[(int)defaultPoolIndex].Value;
                     ulong preferredBlockSize = outBlockVector->GetPreferredBlockSize();
                     if (allocSize > preferredBlockSize)
                     {

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Allocator.Pimpl.cs
@@ -758,7 +758,6 @@ namespace TerraFX.Interop
             }
 
             // Process deafult pools.
-
             if (SupportsResourceHeapTier2())
             {
                 for (nuint heapTypeIndex = 0; heapTypeIndex < D3D12MA_STANDARD_HEAP_TYPE_COUNT; ++heapTypeIndex)
@@ -790,7 +789,7 @@ namespace TerraFX.Interop
                     (D3D12MA_IntrusiveLinkedList<D3D12MA_Pool>*)Unsafe.AsPointer(ref m_Pools[(int)heapTypeIndex]);
                 for (D3D12MA_Pool* pool = poolList->Front(); pool != null; pool = D3D12MA_IntrusiveLinkedList<D3D12MA_Pool>.GetNext(pool))
                 {
-                    pool->GetBlockVector()->AddStats(outStats);
+                    pool->AddStats(outStats);
                 }
             }
 

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CommittedAllocationList.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CommittedAllocationList.cs
@@ -4,6 +4,7 @@
 // Original source is Copyright © Advanced Micro Devices, Inc. All rights reserved. Licensed under the MIT License (MIT).
 
 using System;
+using System.Runtime.CompilerServices;
 using static TerraFX.Interop.D3D12MemAlloc;
 using static TerraFX.Interop.Windows;
 
@@ -16,6 +17,7 @@ namespace TerraFX.Interop
     {
         private bool m_useMutex;
         private D3D12_HEAP_TYPE m_HeapType;
+        private D3D12MA_Pool* m_Pool;
 
         private D3D12MA_RW_MUTEX m_Mutex;
 
@@ -26,14 +28,16 @@ namespace TerraFX.Interop
         {
             pThis.m_useMutex = true;
             pThis.m_HeapType = D3D12_HEAP_TYPE.D3D12_HEAP_TYPE_CUSTOM;
+            pThis.m_Pool = null;
 
             D3D12MA_RW_MUTEX._ctor(ref pThis.m_Mutex);
         }
 
-        public void Init(bool useMutex, D3D12_HEAP_TYPE heapType)
+        public void Init(bool useMutex, D3D12_HEAP_TYPE heapType, D3D12MA_Pool* pool)
         {
             m_useMutex = useMutex;
             m_HeapType = heapType;
+            m_Pool = pool;
         }
 
         public void Dispose()
@@ -48,17 +52,9 @@ namespace TerraFX.Interop
 
         public void CalculateStats([NativeTypeName("StatInfo&")] ref D3D12MA_StatInfo outStats)
         {
-            outStats.BlockCount = 0;
-            outStats.AllocationCount = 0;
-            outStats.UnusedRangeCount = 0;
-            outStats.UsedBytes = 0;
-            outStats.UnusedBytes = 0;
+            ZeroMemory(Unsafe.AsPointer(ref outStats), (nuint)sizeof(D3D12MA_StatInfo));
             outStats.AllocationSizeMin = UINT64_MAX;
-            outStats.AllocationSizeAvg = 0;
-            outStats.AllocationSizeMax = 0;
             outStats.UnusedRangeSizeMin = UINT64_MAX;
-            outStats.UnusedRangeSizeAvg = 0;
-            outStats.UnusedRangeSizeMax = 0;
 
             using D3D12MA_MutexLockRead @lock = new(ref m_Mutex, m_useMutex);
 

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CommittedAllocationParameters.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CommittedAllocationParameters.cs
@@ -1,0 +1,25 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from D3D12MemAlloc.cpp in D3D12MemoryAllocator commit febc1c2cf66eb9211f36da800b50cf73dfde8d68
+// Original source is Copyright © Advanced Micro Devices, Inc. All rights reserved. Licensed under the MIT License (MIT).
+
+using static TerraFX.Interop.D3D12_HEAP_FLAGS;
+
+namespace TerraFX.Interop
+{
+    internal unsafe struct D3D12MA_CommittedAllocationParameters
+    {
+        public D3D12MA_CommittedAllocationList* m_List;
+        public D3D12_HEAP_PROPERTIES m_HeapProperties;
+        public D3D12_HEAP_FLAGS m_HeapFlags;
+
+        public static void _ctor(out D3D12MA_CommittedAllocationParameters pThis)
+        {
+            pThis.m_List = null;
+            pThis.m_HeapProperties = default;
+            pThis.m_HeapFlags = D3D12_HEAP_FLAG_NONE;
+        }
+
+        public readonly bool IsValid() => m_List != null;
+    }
+}

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CurrentBudgetData.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_CurrentBudgetData.cs
@@ -1,6 +1,6 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from D3D12MemAlloc.cpp in D3D12MemoryAllocator commit 5457bcdaee73ee1f3fe6027bbabf959119f88b3d
+// Ported from D3D12MemAlloc.cpp in D3D12MemoryAllocator commit 47bedc01fff10d502622d2eb7b38ae887de83897
 // Original source is Copyright © Advanced Micro Devices, Inc. All rights reserved. Licensed under the MIT License (MIT).
 
 using System.Threading;
@@ -59,6 +59,22 @@ namespace TerraFX.Interop
             Volatile.Write(ref allocationBytes, Volatile.Read(ref allocationBytes) - allocationSize);
 
             ++m_OperationsSinceBudgetFetch;
+        }
+
+        public void AddCommittedAllocation([NativeTypeName("UINT")] uint heapTypeIndex, [NativeTypeName("UINT64")] ulong allocationSize)
+        {
+            AddAllocation(heapTypeIndex, allocationSize);
+
+            ref ulong blockBytes = ref m_BlockBytes[(int)heapTypeIndex];
+            Volatile.Write(ref blockBytes, Volatile.Read(ref blockBytes) + allocationSize);
+        }
+
+        public void RemoveCommittedAllocation([NativeTypeName("UINT")] uint heapTypeIndex, [NativeTypeName("UINT64")] ulong allocationSize)
+        {
+            ref ulong blockBytes = ref m_BlockBytes[(int)heapTypeIndex];
+            Volatile.Write(ref blockBytes, Volatile.Read(ref blockBytes) - allocationSize);
+
+            RemoveAllocation(heapTypeIndex, allocationSize);
         }
     }
 }

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
@@ -73,12 +73,6 @@ namespace TerraFX.Interop
 
         internal D3D12MA_BlockVector* GetBlockVector() => m_BlockVector;
 
-        [return: NativeTypeName("HRESULT")]
-        private int SetMinBytesPimpl([NativeTypeName("UINT64")] ulong minBytes)
-        {
-            return m_BlockVector->SetMinBytes(minBytes);
-        }
-
         private void CalculateStatsPimpl([NativeTypeName("StatInfo&")] D3D12MA_StatInfo* outStats)
         {
             ZeroMemory(outStats, (nuint)sizeof(D3D12MA_StatInfo));

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
@@ -103,6 +103,15 @@ namespace TerraFX.Interop
             PostProcessStatInfo(ref *outStats);
         }
 
+        internal void AddStats([NativeTypeName("Stats&")] D3D12MA_Stats* inoutStats)
+        {
+            D3D12MA_StatInfo poolStatInfo = default;
+            CalculateStats(&poolStatInfo);
+
+            AddStatInfo(ref inoutStats->Total, ref poolStatInfo);
+            AddStatInfo(ref inoutStats->HeapType[(int)HeapTypeToIndex(m_Desc.HeapProperties.Type)], ref poolStatInfo);
+        }
+
         private void SetNamePimpl([NativeTypeName("LPCWSTR")] ushort* Name)
         {
             FreeName();

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_Pool.Pimpl.cs
@@ -71,7 +71,19 @@ namespace TerraFX.Interop
 
         internal readonly D3D12MA_Allocator* GetAllocator() => m_Allocator;
 
+        internal readonly bool SupportsCommittedAllocations() => m_Desc.BlockSize == 0;
+
         internal D3D12MA_BlockVector* GetBlockVector() => m_BlockVector;
+
+        internal readonly D3D12MA_CommittedAllocationList* GetCommittedAllocationList()
+        {
+            if (SupportsCommittedAllocations())
+            {
+                return (D3D12MA_CommittedAllocationList*)Unsafe.AsPointer(ref Unsafe.AsRef(in m_CommittedAllocations));
+            }
+
+            return null;
+        }
 
         private void CalculateStatsPimpl([NativeTypeName("StatInfo&")] D3D12MA_StatInfo* outStats)
         {

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_ResourceClass.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MA_ResourceClass.cs
@@ -1,0 +1,18 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from D3D12MemAlloc.cpp in D3D12MemoryAllocator commit 49fb8acf85d038afbbd5f532ab964fa0835ce819
+// Original source is Copyright © Advanced Micro Devices, Inc. All rights reserved. Licensed under the MIT License (MIT).
+
+using System;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop
+{
+    internal enum D3D12MA_ResourceClass
+    {
+        Unknown,
+        Buffer,
+        Non_RT_DS_Texture,
+        RT_DS_Texture
+    }
+}

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
@@ -18,6 +18,7 @@ namespace TerraFX.Interop
     {
         internal const uint D3D12MA_STANDARD_HEAP_TYPE_COUNT = 3; // Only DEFAULT, UPLOAD, READBACK.
         internal const uint D3D12MA_DEFAULT_POOL_MAX_COUNT = 9;
+        internal const D3D12_HEAP_FLAGS RESOURCE_CLASS_HEAP_FLAGS = D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES;
 
         ////////////////////////////////////////////////////////////////////////////////
         ////////////////////////////////////////////////////////////////////////////////
@@ -751,17 +752,63 @@ namespace TerraFX.Interop
             return tileCount <= 16;
         }
 
-        internal static D3D12_HEAP_FLAGS GetExtraHeapFlagsToIgnore()
-        {
-            D3D12_HEAP_FLAGS result = D3D12_HEAP_FLAG_DENY_BUFFERS | D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES | D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES;
-            return result;
-        }
-
         internal static bool IsHeapTypeStandard(D3D12_HEAP_TYPE type)
         {
             return type == D3D12_HEAP_TYPE_DEFAULT ||
                 type == D3D12_HEAP_TYPE_UPLOAD ||
                 type == D3D12_HEAP_TYPE_READBACK;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static D3D12MA_ResourceClass ResourceDescToResourceClass([NativeTypeName("const D3D12_RESOURCE_DESC_T&")] D3D12_RESOURCE_DESC* resDesc)
+        {
+            if(resDesc->Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+            {
+                return D3D12MA_ResourceClass.Buffer;
+            }
+
+            // Else: it's surely a texture.
+            bool isRenderTargetOrDepthStencil =
+                (resDesc->Flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)) != 0;
+            return isRenderTargetOrDepthStencil ? D3D12MA_ResourceClass.RT_DS_Texture : D3D12MA_ResourceClass.Non_RT_DS_Texture;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static D3D12MA_ResourceClass ResourceDescToResourceClass([NativeTypeName("const D3D12_RESOURCE_DESC_T&")] D3D12_RESOURCE_DESC1* resDesc)
+        {
+            if (resDesc->Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+            {
+                return D3D12MA_ResourceClass.Buffer;
+            }
+
+            // Else: it's surely a texture.
+            bool isRenderTargetOrDepthStencil =
+                (resDesc->Flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)) != 0;
+            return isRenderTargetOrDepthStencil ? D3D12MA_ResourceClass.RT_DS_Texture : D3D12MA_ResourceClass.Non_RT_DS_Texture;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static D3D12MA_ResourceClass HeapFlagsToResourceClass(D3D12_HEAP_FLAGS heapFlags)
+        {
+            bool allowBuffers = (heapFlags & D3D12_HEAP_FLAG_DENY_BUFFERS) == 0;
+            bool allowRtDsTextures = (heapFlags & D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES) == 0;
+            bool allowNonRtDsTextures = (heapFlags & D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES) == 0;
+
+            int allowedGroupCount = (allowBuffers ? 1 : 0) + (allowRtDsTextures ? 1 : 0) + (allowNonRtDsTextures ? 1 : 0);
+            if (allowedGroupCount != 1)
+            {
+                return D3D12MA_ResourceClass.Unknown;
+            }
+            if (allowRtDsTextures)
+            {
+                return D3D12MA_ResourceClass.RT_DS_Texture;
+            }
+            if (allowNonRtDsTextures)
+            {
+                return D3D12MA_ResourceClass.Non_RT_DS_Texture;
+            }
+
+            return D3D12MA_ResourceClass.Buffer;
         }
 
         internal static void AddStatInfoToJson(D3D12MA_JsonWriter* json, D3D12MA_StatInfo* statInfo)

--- a/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
+++ b/sources/Interop/D3D12MemoryAllocator/src/D3D12MemAlloc/D3D12MemAlloc.cs
@@ -759,6 +759,14 @@ namespace TerraFX.Interop
                 type == D3D12_HEAP_TYPE_READBACK;
         }
 
+        internal static D3D12_HEAP_PROPERTIES StandardHeapTypeToHeapProperties(D3D12_HEAP_TYPE type)
+        {
+            D3D12MA_ASSERT(IsHeapTypeStandard(type));
+            D3D12_HEAP_PROPERTIES result = default;
+            result.Type = type;
+            return result;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static D3D12MA_ResourceClass ResourceDescToResourceClass([NativeTypeName("const D3D12_RESOURCE_DESC_T&")] D3D12_RESOURCE_DESC* resDesc)
         {

--- a/tests/Interop/D3D12MemoryAllocator/D3D12MemAllocTests.cs
+++ b/tests/Interop/D3D12MemoryAllocator/D3D12MemAllocTests.cs
@@ -197,6 +197,9 @@ namespace TerraFX.Interop.UnitTests
         public static void TestCustomHeaps() => TestCustomHeaps(in testCtx);
 
         [Test]
+        public static void TestStandardCustomCommittedPlaced() => TestStandardCustomCommittedPlaced(in testCtx);
+
+        [Test]
         public static void TestAliasingMemory() => TestAliasingMemory(in testCtx);
 
         [Test]

--- a/tests/Interop/D3D12MemoryAllocator/D3D12MemAllocTests.cs
+++ b/tests/Interop/D3D12MemoryAllocator/D3D12MemAllocTests.cs
@@ -197,9 +197,6 @@ namespace TerraFX.Interop.UnitTests
         public static void TestCustomHeaps() => TestCustomHeaps(in testCtx);
 
         [Test]
-        public static void TestDefaultPoolMinBytes() => TestDefaultPoolMinBytes(in testCtx);
-
-        [Test]
         public static void TestAliasingMemory() => TestAliasingMemory(in testCtx);
 
         [Test]

--- a/tests/Interop/D3D12MemoryAllocator/src/Tests/D3D12MemAllocTests.cs
+++ b/tests/Interop/D3D12MemoryAllocator/src/Tests/D3D12MemAllocTests.cs
@@ -10,9 +10,11 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using NUnit.Framework;
 using static TerraFX.Interop.D3D12_CPU_PAGE_PROPERTY;
+using static TerraFX.Interop.D3D12_FEATURE;
 using static TerraFX.Interop.D3D12_HEAP_FLAGS;
 using static TerraFX.Interop.D3D12_HEAP_TYPE;
 using static TerraFX.Interop.D3D12_MEMORY_POOL;
+using static TerraFX.Interop.D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS;
 using static TerraFX.Interop.D3D12_RESOURCE_BARRIER_TYPE;
 using static TerraFX.Interop.D3D12_RESOURCE_DIMENSION;
 using static TerraFX.Interop.D3D12_RESOURCE_FLAGS;
@@ -1789,9 +1791,21 @@ namespace TerraFX.Interop.UnitTests
             }
         }
 
+        private static bool IsProtectedResourceSessionSupported([NativeTypeName("const TestContext&")] in TestContext ctx)
+        {
+            D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT support = default;
+            CHECK_HR(ctx.device->CheckFeatureSupport(D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_SUPPORT, &support, (uint)sizeof(D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT)));
+            return support.Support > D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAG_NONE;
+        }
+
         private static void TestDevice4([NativeTypeName("const TestContext&")] in TestContext ctx)
         {
             Console.WriteLine("Test ID3D12Device4");
+
+            if (!IsProtectedResourceSessionSupported(in ctx))
+            {
+                Assert.Inconclusive("D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_SUPPORT returned no support for protected resource session.");
+            }
 
             using ComPtr<ID3D12Device4> dev4 = default;
 

--- a/tests/Interop/D3D12MemoryAllocator/src/Tests/D3D12MemAllocTests.cs
+++ b/tests/Interop/D3D12MemoryAllocator/src/Tests/D3D12MemAllocTests.cs
@@ -709,26 +709,6 @@ namespace TerraFX.Interop.UnitTests
 
                 CHECK_BOOL(string.Compare(poolName, NAME) == 0);
 
-                // # SetMinBytes
-
-                CHECK_HR(pool.Get()->SetMinBytes(15 * MEGABYTE));
-
-                pool.Get()->CalculateStats(&poolStats);
-
-                CHECK_BOOL(poolStats.BlockCount == 2);
-                CHECK_BOOL(poolStats.AllocationCount == 0);
-                CHECK_BOOL(poolStats.UsedBytes == 0);
-                CHECK_BOOL(poolStats.UnusedBytes == poolStats.BlockCount * poolDesc.BlockSize);
-
-                CHECK_HR(pool.Get()->SetMinBytes(0));
-
-                pool.Get()->CalculateStats(&poolStats);
-
-                CHECK_BOOL(poolStats.BlockCount == 1);
-                CHECK_BOOL(poolStats.AllocationCount == 0);
-                CHECK_BOOL(poolStats.UsedBytes == 0);
-                CHECK_BOOL(poolStats.UnusedBytes == poolStats.BlockCount * poolDesc.BlockSize);
-
                 // # Create buffers 2x 5 MB
 
                 D3D12MA_ALLOCATION_DESC allocDesc = default;
@@ -953,28 +933,6 @@ namespace TerraFX.Interop.UnitTests
             heapProps.MemoryPoolPreference = D3D12_MEMORY_POOL_L0; // System memory
             HRESULT hr = TestCustomHeap(ctx, heapProps);
             CHECK_HR(hr);
-        }
-
-        private static void TestDefaultPoolMinBytes([NativeTypeName("const TestContext&")] in TestContext ctx)
-        {
-            D3D12MA_Stats stats;
-            ctx.allocator->CalculateStats(&stats);
-            ulong gpuAllocatedBefore = stats.HeapType[0].UsedBytes + stats.HeapType[0].UnusedBytes;
-
-            ulong gpuAllocatedMin = gpuAllocatedBefore * 105 / 100;
-
-            CHECK_HR(ctx.allocator->SetDefaultHeapMinBytes(D3D12_HEAP_TYPE_DEFAULT, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS, CeilDiv(gpuAllocatedMin, 3ul)));
-            CHECK_HR(ctx.allocator->SetDefaultHeapMinBytes(D3D12_HEAP_TYPE_DEFAULT, D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES, CeilDiv(gpuAllocatedMin, 3ul)));
-            CHECK_HR(ctx.allocator->SetDefaultHeapMinBytes(D3D12_HEAP_TYPE_DEFAULT, D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES, CeilDiv(gpuAllocatedMin, 3ul)));
-
-            ctx.allocator->CalculateStats(&stats);
-            ulong gpuAllocatedAfter = stats.HeapType[0].UsedBytes + stats.HeapType[0].UnusedBytes;
-
-            CHECK_BOOL(gpuAllocatedAfter >= gpuAllocatedMin);
-
-            CHECK_HR(ctx.allocator->SetDefaultHeapMinBytes(D3D12_HEAP_TYPE_DEFAULT, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS, 0));
-            CHECK_HR(ctx.allocator->SetDefaultHeapMinBytes(D3D12_HEAP_TYPE_DEFAULT, D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES, 0));
-            CHECK_HR(ctx.allocator->SetDefaultHeapMinBytes(D3D12_HEAP_TYPE_DEFAULT, D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES, 0));
         }
 
         private static void TestAliasingMemory([NativeTypeName("const TestContext&")] in TestContext ctx)
@@ -1879,7 +1837,6 @@ namespace TerraFX.Interop.UnitTests
             TestOtherComInterface(in ctx);
             TestCustomPools(in ctx);
             TestCustomHeaps(in ctx);
-            TestDefaultPoolMinBytes(in ctx);
             TestAliasingMemory(in ctx);
             TestMapping(in ctx);
             TestStats(in ctx);

--- a/tests/Interop/D3D12MemoryAllocator/src/Tests/D3D12MemAllocTests.cs
+++ b/tests/Interop/D3D12MemoryAllocator/src/Tests/D3D12MemAllocTests.cs
@@ -13,7 +13,6 @@ using static TerraFX.Interop.D3D12_CPU_PAGE_PROPERTY;
 using static TerraFX.Interop.D3D12_HEAP_FLAGS;
 using static TerraFX.Interop.D3D12_HEAP_TYPE;
 using static TerraFX.Interop.D3D12_MEMORY_POOL;
-using static TerraFX.Interop.D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS;
 using static TerraFX.Interop.D3D12_RESOURCE_BARRIER_TYPE;
 using static TerraFX.Interop.D3D12_RESOURCE_DIMENSION;
 using static TerraFX.Interop.D3D12_RESOURCE_FLAGS;
@@ -1008,6 +1007,10 @@ namespace TerraFX.Interop.UnitTests
 
                             bool expectSuccess = !neverAllocate; // NEVER_ALLOCATE should always fail with COMMITTED.
                             CHECK_BOOL(expectSuccess == SUCCEEDED(hr));
+                            if (SUCCEEDED(hr) && useCommitted)
+                            {
+                                CHECK_BOOL(allocPtr->GetHeap() == null); // Committed allocation has implicit heap.
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Follow up to https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/issues/11

This PR includes a port of the following commits:
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/9d6ccc289dd37d43ce544129681da16948b16277
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/b78ae97f6658f797b0637b4ce1e01a528cec961d
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/b2c51830784743515a21aed8a6184a8b8e42a5a2
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/49fb8acf85d038afbbd5f532ab964fa0835ce819
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/897976113c044e3761acb5cf4fe0f2a722e807d7
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/7164a23feaa19f36cea6d9d1f040666c33c68421
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/febc1c2cf66eb9211f36da800b50cf73dfde8d68
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/47bedc01fff10d502622d2eb7b38ae887de83897
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/d647ce120286bd64327021dfec57dbca846ab18a
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/cb0376a32ea270b5f3e9e5a9ccc04567a20c18d8
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/e37363c0f1cb015cdd70252a59d3356a98b999db
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/4dedc35e8f94366a50ed9f9dbf517b5af818268f
- https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/17df03f5ff04ced0dc4163a1333d1ea7c1b3615b