### PR TITLE
Bump TerraFX to 10.0.20348-rc2.1414617443

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -33,7 +33,7 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="TerraFX.Interop.Windows" Version="10.0.20348-rc2.1411011823" />
+    <PackageReference Update="TerraFX.Interop.Windows" Version="10.0.20348-rc2.1414617443" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />


### PR DESCRIPTION
Just bumped the `TerraFX.Interop.Windows` dependency to `10.0.20348-rc2.1414617443`.