### PR TITLE
Added a test to make sure committed allocations of custom pools work

### DIFF
--- a/tests/Interop/D3D12MemoryAllocator/D3D12MemAllocTests.cs
+++ b/tests/Interop/D3D12MemoryAllocator/D3D12MemAllocTests.cs
@@ -206,6 +206,9 @@ namespace TerraFX.Interop.DirectX.UnitTests
         public static void TestCustomPool_MinAllocationAlignment() => TestCustomPool_MinAllocationAlignment(in testCtx);
 
         [Test]
+        public static void TestCustomPool_Committed() => TestCustomPool_Committed(in testCtx);
+
+        [Test]
         public static void TestCustomHeaps() => TestCustomHeaps(in testCtx);
 
         [Test]


### PR DESCRIPTION
Port of https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/commit/4550e949558314a9960c15d9e808de54cec4a3b6.

Related to https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/issues/24.